### PR TITLE
Standardize imaging arrays to always use 4D shape (T, H, W, P)

### DIFF
--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -23,13 +23,15 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
     The `_main_ids` attribute is used here for multi-plane imaging objects.
     """
 
-    def __init__(self, sampling_frequency: float, shape: tuple | list | np.ndarray, plane_ids: list | None = None):
-        if plane_ids is None:
-            plane_ids = [0]  # dummy single plane
-        BaseExtractor.__init__(self, plane_ids)
+    def __init__(self, sampling_frequency: float, shape: tuple | list | np.ndarray):
+        # Should we allow users to provide 2D shape (H, W) for single plane imaging?
+        if len(shape) == 2:
+            shape = (shape[0], shape[1], 1)
+        assert len(shape) == 3, "Shape must be a tuple/list/array of length 3 (height, width, planes)"
+
+        BaseExtractor.__init__(self, range(0, shape[2]))
         self._sampling_frequency = float(sampling_frequency)
-        assert len(shape) == 2, "Shape must be a tuple/list/array of length 2 (height, width)"
-        self._image_shape = np.array(shape)
+        self._image_shape = np.array(shape) # Image is intended as a volume (H, W, planes)
         self._average_image = None
 
     def _repr_header(self, display_name=True):
@@ -162,10 +164,10 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         return self._sampling_frequency
 
     def get_sample_size_in_bytes(self):
-        return self.get_num_pixels() * self.get_num_planes() * np.dtype(self.get_dtype()).itemsize
+        return self.get_num_pixels() * np.dtype(self.get_dtype()).itemsize
 
     def get_shape(self, segment_index: int | None = None) -> tuple:
-        """Get the shape of the imaging data as (num_samples, height, width).
+        """Get the shape of the imaging data as (num_samples, height, width, planes).
 
         Parameters
         ----------
@@ -175,7 +177,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         Returns
         -------
         tuple
-            The shape of the imaging data as (num_samples, height, width).
+            The shape of the imaging data as (num_samples, height, width, planes).
         """
         if segment_index is None:
             if self.get_num_segments() == 1:
@@ -183,11 +185,9 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             else:
                 raise ValueError("segment_index must be provided for multi-segment imaging data.")
         num_samples = self.get_num_samples(segment_index=segment_index)
-        if self.get_num_planes() > 1:
-            return (num_samples, *self.image_shape, self.get_num_planes())
-        else:
-            return (num_samples, *self.image_shape)
-
+        
+        return (num_samples, *self.image_shape)
+        
     def get_data(self, start_frame: int, end_frame: int, segment_index: int | None = None, **kwargs) -> np.ndarray:
         return self.get_series(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
 
@@ -307,6 +307,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         chunk_size: int | None = None,
         recompute: bool = False,
     ) -> np.ndarray:
+        #  we will get the average volume image across the given frames
         if self._average_image is not None and not recompute:
             return self._average_image
         else:
@@ -373,7 +374,6 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
                 file_paths=file_paths,
                 sampling_frequency=self.get_sampling_frequency(),
                 image_shape=self.image_shape,
-                num_planes=self.get_num_planes(),
                 dtype=dtype,
                 t_starts=t_starts,
                 file_offset=0,

--- a/src/photon_mosaic/core/binaryimaging.py
+++ b/src/photon_mosaic/core/binaryimaging.py
@@ -46,19 +46,10 @@ class BinaryImaging(BaseImaging):
         sampling_frequency,
         image_shape,
         dtype,
-        num_planes: int = 1,
-        plane_ids: list[int] | None = None,
         t_starts=None,
         file_offset=0,
     ):
-        if num_planes > 1:
-            if plane_ids is None:
-                plane_ids = list(range(num_planes))
-            else:
-                assert len(plane_ids) == num_planes, "plane_ids length must match num_planes"
-        else:
-            plane_ids = [0]
-        BaseImaging.__init__(self, sampling_frequency, image_shape, plane_ids=plane_ids)
+        BaseImaging.__init__(self, sampling_frequency, image_shape)
 
         if isinstance(file_paths, list):
             # several segment
@@ -84,7 +75,6 @@ class BinaryImaging(BaseImaging):
                 t_start,
                 image_shape,
                 dtype,
-                num_planes,
                 file_offset,
             )
             self.add_imaging_segment(imaging_segment)
@@ -96,8 +86,6 @@ class BinaryImaging(BaseImaging):
             "image_shape": image_shape,
             "dtype": dtype.str,
             "file_offset": file_offset,
-            "num_planes": num_planes,
-            "plane_ids": plane_ids,
         }
 
     def is_binary_compatible(self) -> bool:
@@ -108,7 +96,6 @@ class BinaryImaging(BaseImaging):
             file_paths=self._kwargs["file_paths"],
             dtype=np.dtype(self._kwargs["dtype"]),
             image_shape=self._kwargs["image_shape"],
-            num_planes=self._kwargs["num_planes"],
             file_offset=self._kwargs["file_offset"],
         )
         return d
@@ -127,17 +114,16 @@ class BinaryImaging(BaseImaging):
 
 
 class BinaryImagingSegment(BaseImagingSegment):
-    def __init__(self, file_path, sampling_frequency, t_start, image_shape, dtype, num_planes, file_offset):
+    def __init__(self, file_path, sampling_frequency, t_start, image_shape, dtype, file_offset):
         BaseImagingSegment.__init__(self, sampling_frequency=sampling_frequency, t_start=t_start)
         self.image_shape = image_shape
         self.dtype = np.dtype(dtype)
         self.file_offset = file_offset
         self.file_path = file_path
         self.file = open(self.file_path, "rb")
-        self.bytes_per_sample = np.prod(image_shape) * num_planes * self.dtype.itemsize
+        self.bytes_per_sample = np.prod(image_shape) * self.dtype.itemsize
         self.data_size_in_bytes = Path(file_path).stat().st_size - file_offset
         self.num_samples = self.data_size_in_bytes // self.bytes_per_sample
-        self.num_planes = num_planes
 
     def get_num_samples(self) -> int:
         """Returns the number of samples in this signal block
@@ -179,16 +165,15 @@ class BinaryImagingSegment(BaseImagingSegment):
         # Create a numpy array using the mmap object as the buffer
         # Note that the shape must be recalculated based on the new data chunk
         shape: tuple[int, int, int, int]
-        if self.num_planes > 1:
-            shape = (
-                (end_frame - start_frame),
-                self.image_shape[0],
-                self.image_shape[1],
-                self.num_planes,
-            )
-        else:
-            shape = ((end_frame - start_frame), self.image_shape[0], self.image_shape[1], 1)
-
+        shape = (
+            (end_frame - start_frame),
+            self.image_shape[0],
+            self.image_shape[1],
+            self.image_shape[2], 
+            # We could also read only the specific planes here
+            # if we implemented more complex memory mapping offsets
+        )
+        
         # Now the entire array should correspond to the data between start_frame and end_frame,
         # so we can use it directly
         series = np.ndarray(
@@ -199,11 +184,8 @@ class BinaryImagingSegment(BaseImagingSegment):
         )
 
         # Slice planes if needed
-        if plane_indices is not None and self.num_planes > 1:
-            series = series[:, :, :, plane_indices]
-        elif self.num_planes == 1:
-            series = series[:, :, :, 0]
-
+        series = series[:, :, :, plane_indices] if plane_indices is not None else series
+        
         return series
 
     def __del__(self):  # pragma: no cover

--- a/src/photon_mosaic/core/generators.py
+++ b/src/photon_mosaic/core/generators.py
@@ -12,7 +12,6 @@ def generate_random_imaging(
     width: int = 256,
     sampling_frequency: float = 30.0,
     num_planes: int = 1,
-    plane_ids: list[int] | None = None,
     seed: int | None = None,
 ) -> NumpyImaging:
     """Generate a random NumpyImaging object for testing.
@@ -39,10 +38,8 @@ def generate_random_imaging(
     videos = []
     for n_frames in num_frames:
         video = rng.random((n_frames, height, width, num_planes))
-        if num_planes == 1:
-            video = video[..., 0]
         videos.append(video)
-    return NumpyImaging(imaging_series=videos, sampling_frequency=sampling_frequency, plane_ids=plane_ids)
+    return NumpyImaging(imaging_series=videos, sampling_frequency=sampling_frequency)
 
 
 def generate_rois(

--- a/src/photon_mosaic/core/numpyimaging.py
+++ b/src/photon_mosaic/core/numpyimaging.py
@@ -23,7 +23,6 @@ class NumpyImaging(BaseImaging):
         imaging_series: ArrayType | list[ArrayType],
         sampling_frequency: FloatType,
         time_vectors: ArrayType | list[ArrayType] | None = None,
-        plane_ids: list[int] | None = None,
         seed=None,
     ):
         """Create a NumpyImagingExtractor from a numpy array or list of numpy arrays.
@@ -41,8 +40,6 @@ class NumpyImaging(BaseImaging):
             Sampling frequency of the video in Hz.
         time_vectors: ArrayType | list[ArrayType] | None, default: None
             Optional time vector(s) for the video.
-        plane_ids: list[int] | None, default: None
-            Optional list of plane IDs for the video.
         """
         if isinstance(imaging_series, np.ndarray):
             videos = [imaging_series]
@@ -61,18 +58,12 @@ class NumpyImaging(BaseImaging):
                 raise ValueError(
                     "'timeseries' must be a 3D or 4D numpy array (num_frames, height, width, [num_planes])"
                 )
+            if len(video.shape) == 3:
+                video = video[:, :, :, np.newaxis]  # Add a planes dimension
             shapes.append(video.shape[1:])
         if not all(shape == shapes[0] for shape in shapes):
-            raise ValueError("All segments must have the same image shape (height, width) and number of planes")
-        height, width = shapes[0][0:2]
-        num_planes = shapes[0][2] if len(shapes[0]) == 3 else 1
-
-        if num_planes > 1:
-            if plane_ids is None:
-                plane_ids = list(range(num_planes))
-            else:
-                assert len(plane_ids) == num_planes, "plane_ids length must match num_planes"
-
+            raise ValueError("All segments must have the same image shape (height, width, planes)")
+        
         # Check consistency of time vectors
         if time_vectors is not None:
             if num_segments == 1 and isinstance(time_vectors, np.ndarray):
@@ -81,7 +72,7 @@ class NumpyImaging(BaseImaging):
         else:
             time_vectors = [None] * num_segments
 
-        BaseImaging.__init__(self, shape=(height, width), sampling_frequency=sampling_frequency, plane_ids=plane_ids)
+        BaseImaging.__init__(self, shape=shapes[0], sampling_frequency=sampling_frequency)
 
         for video, time_vector in zip(videos, time_vectors):
             self.add_imaging_segment(
@@ -96,7 +87,6 @@ class NumpyImaging(BaseImaging):
             "imaging_series": imaging_series,
             "sampling_frequency": self._sampling_frequency,
             "time_vectors": time_vectors,
-            "plane_ids": plane_ids,
             "seed": seed,
         }
 
@@ -134,10 +124,8 @@ class NumpyImagingSegment(BaseImagingSegment):
         """
         start = start_frame if start_frame is not None else 0
         end = end_frame if end_frame is not None else self._video.shape[0]
-        if self._video.ndim == 4 and plane_indices is not None:
-            return self._video[start:end, :, :, plane_indices]
-        else:
-            return self._video[start:end, ...]
+        return self._video[start:end, :, :, plane_indices] if plane_indices is not None else self._video[start:end]
+        
 
     def get_num_samples(self) -> int:
         """Returns the number of samples in this signal segment

--- a/src/photon_mosaic/core/tests/test_baseimaging.py
+++ b/src/photon_mosaic/core/tests/test_baseimaging.py
@@ -11,8 +11,8 @@ def test_random_imaging_basic_properties():
     assert imaging.get_num_segments() == 1
     assert imaging.get_num_frames() == num_frames
     assert imaging.get_num_samples() == num_frames
-    assert tuple(imaging.image_shape) == (h, w)
-    assert imaging.get_shape() == (num_frames, h, w)
+    assert tuple(imaging.image_shape) == (h, w, 1)
+    assert imaging.get_shape() == (num_frames, h, w, 1)
 
     dt = imaging.get_dtype()
     assert np.dtype(dt).kind == "f"
@@ -23,10 +23,10 @@ def test_random_imaging_get_series_default_and_slicing():
     imaging = generate_random_imaging(num_frames=12, height=6, width=7, sampling_frequency=20.0, seed=1)
 
     full = imaging.get_series()
-    assert full.shape == (12, 6, 7)
+    assert full.shape == (12, 6, 7, 1)
 
     sl = imaging.get_series(start_frame=2, end_frame=5)
-    assert sl.shape == (3, 6, 7)
+    assert sl.shape == (3, 6, 7, 1)
     np.testing.assert_allclose(sl, full[2:5])
 
 
@@ -127,8 +127,8 @@ def test_baseimaging_multi_segment_requires_segment_index():
     # Works when segment_index is provided
     assert imaging.get_num_samples(segment_index=0) == 10
     assert imaging.get_num_samples(segment_index=1) == 20
-    assert imaging.get_series(segment_index=1).shape == (20, h, w)
-    assert imaging.get_shape(segment_index=0) == (10, h, w)
+    assert imaging.get_series(segment_index=1).shape == (20, h, w, 1)
+    assert imaging.get_shape(segment_index=0) == (10, h, w, 1)
 
     # Run repr_html
     str_html = imaging._repr_html_()
@@ -139,13 +139,13 @@ def test_get_average_image_caches_and_recompute_replaces():
     imaging = generate_random_imaging(num_frames=25, height=8, width=6, sampling_frequency=30.0, seed=6)
 
     avg1 = imaging.get_average_image(num_chunks=2, chunk_size=5)
-    assert avg1.shape == (8, 6)
+    assert avg1.shape == (8, 6, 1)
 
     avg2 = imaging.get_average_image(num_chunks=2, chunk_size=5)
     assert avg2 is avg1  # cached
 
     avg3 = imaging.get_average_image(num_chunks=2, chunk_size=5, recompute=True)
-    assert avg3.shape == (8, 6)
+    assert avg3.shape == (8, 6, 1)
     assert avg3 is not avg1
 
 
@@ -157,24 +157,22 @@ def test_get_average_image_caches_and_recompute_replaces():
 def test_multiplane_basic_shape_and_plane_ids():
     n, h, w, p = 7, 5, 6, 3
     sf = 20.0
-    plane_ids = [10, 20, 30]
     imaging = generate_random_imaging(
         num_frames=n,
         height=h,
         width=w,
         sampling_frequency=sf,
         num_planes=p,
-        plane_ids=plane_ids,
         seed=0,
     )
 
     assert imaging.get_num_segments() == 1
     assert imaging.get_num_planes() == p and imaging.num_planes == p
-    assert np.array_equal(imaging.plane_ids, plane_ids)
+    assert np.array_equal(imaging.plane_ids, list(range(p)))
     assert imaging.get_shape() == (n, h, w, p)
     assert imaging.get_series().shape == (n, h, w, p)
     # slice get_Series by plane_ids
-    assert imaging.get_series(plane_ids=[10, 20]).shape == (n, h, w, 2)
+    assert imaging.get_series(plane_ids=[1, 2]).shape == (n, h, w, 2)
 
 
 def test_multiplane_average_image_shape_and_caching():
@@ -211,5 +209,6 @@ def test_generate_random_imaging_multiplane_has_expected_plane_dimension_and_sel
     assert full.shape == (n, h, w, p)
 
     sel = imaging.get_series(plane_ids=[1])
-    assert sel.shape[:-1] == (n, h, w)
-    np.testing.assert_allclose(sel[..., 0], full[..., 1])
+    assert sel.shape == (n, h, w, 1)
+    np.all(sel[..., 0] == full[..., 1])
+    

--- a/src/photon_mosaic/core/tests/test_binaryimaging.py
+++ b/src/photon_mosaic/core/tests/test_binaryimaging.py
@@ -19,32 +19,31 @@ def _write_binary_file(path: Path, array: np.ndarray, file_offset: int = 0) -> N
 def test_binaryimaging_single_segment_single_plane_roundtrip(tmp_path: Path):
     n_frames, h, w = 11, 3, 4
     dtype = np.uint16
-    data = np.arange(n_frames * h * w, dtype=dtype).reshape(n_frames, h, w)
-
+    data = np.arange(n_frames * h * w, dtype=dtype).reshape(n_frames, h, w, 1) 
+    
     fpath = tmp_path / "video.dat"
     _write_binary_file(fpath, data)
 
     imaging = BinaryImaging(
         file_paths=str(fpath),
         sampling_frequency=10.0,
-        image_shape=(h, w),
+        image_shape=(h, w, 1),
         dtype=dtype,
-        num_planes=1,
     )
 
     assert imaging.get_num_segments() == 1
     assert imaging.get_num_frames() == n_frames
-    assert tuple(imaging.image_shape) == (h, w)
+    assert tuple(imaging.image_shape) == (h, w, 1)
     assert imaging.is_binary_compatible()
     binary_desc = imaging.get_binary_description()
     assert binary_desc is not None
 
     out = imaging.get_series(start_frame=0, end_frame=5)
-    assert out.shape == (5, h, w)
+    assert out.shape == (5, h, w, 1)
     np.testing.assert_array_equal(out, data[:5])
 
     out2 = imaging.get_series(start_frame=None, end_frame=None)
-    assert out2.shape == (n_frames, h, w)
+    assert out2.shape == (n_frames, h, w, 1)
     np.testing.assert_array_equal(out2, data)
 
     # test deleting
@@ -62,10 +61,8 @@ def test_binaryimaging_multi_plane_and_plane_selection(tmp_path: Path):
     imaging = BinaryImaging(
         file_paths=str(fpath),
         sampling_frequency=20.0,
-        image_shape=(h, w),
+        image_shape=(h, w, p),
         dtype=dtype,
-        num_planes=p,
-        plane_ids=list(range(p)),
     )
 
     out_all = imaging.get_series(0, n_frames)
@@ -99,10 +96,9 @@ def test_binaryimaging_with_tstarts(tmp_path: Path):
     imaging = BinaryImaging(
         file_paths=[str(f0), str(f1)],
         sampling_frequency=10.0,
-        image_shape=(h, w),
+        image_shape=(h, w, 1),
         dtype=dtype,
         t_starts=t_starts,
-        num_planes=1,
     )
 
     assert imaging.get_num_segments() == 2
@@ -120,8 +116,8 @@ def test_binaryimaging_multiple_segments(tmp_path: Path):
     h, w = 3, 3
     dtype = np.uint8
 
-    data0 = np.arange(5 * h * w, dtype=dtype).reshape(5, h, w)
-    data1 = np.arange(8 * h * w, dtype=dtype).reshape(8, h, w) + 100
+    data0 = np.arange(5 * h * w, dtype=dtype).reshape(5, h, w, 1)
+    data1 = np.arange(8 * h * w, dtype=dtype).reshape(8, h, w, 1) + 100
 
     f0 = tmp_path / "seg0.dat"
     f1 = tmp_path / "seg1.dat"
@@ -131,9 +127,8 @@ def test_binaryimaging_multiple_segments(tmp_path: Path):
     imaging = BinaryImaging(
         file_paths=[str(f0), str(f1)],
         sampling_frequency=5.0,
-        image_shape=(h, w),
+        image_shape=(h, w, 1),
         dtype=dtype,
-        num_planes=1,
     )
 
     assert imaging.get_num_segments() == 2
@@ -151,16 +146,15 @@ def test_binaryimaging_file_offset(tmp_path: Path):
     dtype = np.float32
     file_offset = 64
 
-    data = np.linspace(0, 1, n_frames * h * w, dtype=dtype).reshape(n_frames, h, w)
+    data = np.linspace(0, 1, n_frames * h * w, dtype=dtype).reshape(n_frames, h, w, 1)
     fpath = tmp_path / "offset.dat"
     _write_binary_file(fpath, data, file_offset=file_offset)
 
     imaging = BinaryImaging(
         file_paths=str(fpath),
         sampling_frequency=30.0,
-        image_shape=(h, w),
+        image_shape=(h, w, 1),
         dtype=dtype,
-        num_planes=1,
         file_offset=file_offset,
     )
 
@@ -172,7 +166,7 @@ def test_baseimaging_save_binary_with_multiprocessing(tmp_path: Path):
     # Create a small source BinaryImaging (acts as a generic BaseImaging instance for save()).
     n_frames, h, w = 23, 4, 6
     dtype = np.int16
-    data = np.arange(n_frames * h * w, dtype=dtype).reshape(n_frames, h, w)
+    data = np.arange(n_frames * h * w, dtype=dtype).reshape(n_frames, h, w, 1)
 
     src_path = tmp_path / "src.dat"
     _write_binary_file(src_path, data)
@@ -180,9 +174,8 @@ def test_baseimaging_save_binary_with_multiprocessing(tmp_path: Path):
     imaging = BinaryImaging(
         file_paths=str(src_path),
         sampling_frequency=10.0,
-        image_shape=(h, w),
+        image_shape=(h, w, 1),
         dtype=dtype,
-        num_planes=1,
     )
 
     out_folder = tmp_path / "saved_binary"

--- a/src/photon_mosaic/core/tests/test_generators.py
+++ b/src/photon_mosaic/core/tests/test_generators.py
@@ -14,8 +14,8 @@ def test_generate_random_imaging_int_vs_singleton_tuple_same_output():
     assert imaging_int.get_num_segments() == 1
     assert imaging_tuple.get_num_segments() == 1
 
-    np.testing.assert_allclose(imaging_int.get_series(), imaging_tuple.get_series())
-    assert imaging_int.get_shape() == imaging_tuple.get_shape() == (n, h, w)
+    np.testing.assert_array_equal(imaging_int.get_series(), imaging_tuple.get_series())
+    assert imaging_int.get_shape() == imaging_tuple.get_shape() == (n, h, w, 1)
 
 
 def test_generate_random_imaging_multisegment_shapes_and_reproducibility_multiplane():
@@ -58,9 +58,9 @@ def test_generate_random_imaging_num_planes_1_returns_3d_series():
     imaging = generate_random_imaging(num_frames=n, height=h, width=w, sampling_frequency=10.0, num_planes=1, seed=0)
 
     series = imaging.get_series()
-    assert series.shape == (n, h, w)
-    assert series.ndim == 3
-    assert imaging.get_shape() == (n, h, w)
+    assert series.shape == (n, h, w, 1)
+    assert series.ndim == 4
+    assert imaging.get_shape() == (n, h, w, 1)  
 
 
 def test_generate_rois_default_roi_ids_and_deterministic_masks():

--- a/src/photon_mosaic/core/tests/test_numpyimaging.py
+++ b/src/photon_mosaic/core/tests/test_numpyimaging.py
@@ -67,16 +67,7 @@ def test_numpyimaging_time_vectors_length_must_match_num_segments():
         NumpyImaging(imaging_series=[v1, v2], sampling_frequency=10.0, time_vectors=tv)
 
 
-def test_numpyimaging_plane_ids_generated_for_4d_video_and_validated():
-    # 4D video: (frames, height, width, planes)
-    video = np.zeros((4, 6, 7, 3), dtype=np.float32)
-
-    im = NumpyImaging(imaging_series=video, sampling_frequency=20.0, plane_ids=None)
-    assert im._kwargs["plane_ids"] == [0, 1, 2]
-
-    with pytest.raises(AssertionError, match="plane_ids length must match num_planes"):
-        NumpyImaging(imaging_series=video, sampling_frequency=20.0, plane_ids=[0, 1])
-
+# Plane ids argument has been removed
 
 def test_numpyimagingsegment_get_num_samples():
     video = np.zeros((11, 2, 3), dtype=np.float32)
@@ -85,7 +76,7 @@ def test_numpyimagingsegment_get_num_samples():
 
 
 def test_numpyimagingsegment_get_series_3d_basic_slicing():
-    video = np.arange(5 * 3 * 4, dtype=np.int32).reshape(5, 3, 4)
+    video = np.arange(5 * 3 * 4, dtype=np.int32).reshape(5, 3, 4, 1)
     seg = NumpyImagingSegment(video=video, sampling_frequency=1.0)
 
     out_all = seg.get_series()


### PR DESCRIPTION
Me and @alessandrofelder worked on the following.

### Changes
- **Breaking change**: All imaging data now consistently uses 4D arrays with shape `(num_frames, height, width, num_planes)`
- Removed `plane_ids` parameter. Plane IDs auto-generated as `range(num_planes)` to maintain consistency with `BaseExtractor` constructor
- `image_shape` now includes plane dimension: `(height, width, num_planes)` instead of `(height, width)`

### Open question: Terminology from neuroscience/microscopy perspective
**Is an "image" 2D or 3D?** From a microscopy background, should we consider:
- Current approach: `image_shape` includes planes (treating image as volumetric)
- Alternative: Separate `image_shape` (H, W) from `volume_shape` (H, W, P)?
- Planes get special treatment with dedicated property and attribute... should width and height have as well?

### Limitations
- **ROI classes unchanged**: Deferring 2D vs 3D segmentation decisions 🙈
- **Binary imaging slicing**: Currently slices by time dimension with memmap. Slicing by planes would be more efficient but requires more complex offset calculations... possible future work with Dask! 🤞🏻
