### PR TITLE
`segments` -> `epochs` (where possible) and `samples` -> `frames`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -1,4 +1,4 @@
-from .baseimaging import BaseImaging, BaseImagingSegment
+from .baseimaging import BaseImaging, BaseImagingEpoch
 from .baserois import BaseRois
 from .numpyimaging import NumpyImaging
 from .generators import generate_random_imaging, generate_rois

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -32,7 +32,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
 
     def _repr_header(self, display_name=True):
         """Generate text representation of the BaseImaging object."""
-        num_samples = [self.get_num_samples(segment_index=i) for i in range(self.get_num_segments())]
+        num_frames = [self.get_num_frames(epoch_index=i) for i in range(self.get_num_epochs())]
         shape = self._shape
         dtype = self.get_dtype()
         sf_hz = self.sampling_frequency
@@ -44,15 +44,15 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             sampling_frequency_repr = f"{sf_hz:0.1f} Hz"
 
         # Calculate duration
-        durations = [ns / sf_hz for ns in num_samples]
+        durations = [ns / sf_hz for ns in num_frames]
         duration_repr = [convert_seconds_to_str(duration) for duration in durations]
 
         # Calculate memory size using product of all dimensions in image_size
-        memory_sizes = [ns * prod(shape) * dtype.itemsize for ns in num_samples]
+        memory_sizes = [ns * prod(shape) * dtype.itemsize for ns in num_frames]
         memory_repr = [convert_bytes_to_str(memory_size) for memory_size in memory_sizes]
 
-        if self.get_num_segments() == 1:
-            num_samples = num_samples[0]
+        if self.get_num_epochs() == 1:
+            num_frames = num_frames[0]
             duration_repr = duration_repr[0]
             memory_repr = memory_repr[0]
 
@@ -66,7 +66,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         return (
             f"{name}:\n"
             f"{sampling_frequency_repr} - "
-            f"{self.get_num_segments()} segments - "
+            f"{self.get_num_epochs()} epochs - "
             f"{shape_repr} - "
             f"{duration_repr} - "
             f"{dtype} dtype - "
@@ -82,21 +82,19 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
 
         html_header = f"<div style='{border_style}'><strong>{self._repr_header(display_name)}</strong></div>"
 
-        html_segments = ""
-        if self.get_num_segments() > 1:
-            html_segments += f"<details style='{common_style}'>  <summary><strong>Segments</strong></summary><ol>"
-            for segment_index in range(self.get_num_segments()):
-                samples = self.get_num_samples(segment_index)
-                duration = self.get_duration(segment_index)
-                memory_size = self.get_memory_size(segment_index)
+        html_epochs = ""
+        if self.get_num_epochs() > 1:
+            html_epochs += f"<details style='{common_style}'>  <summary><strong>Epochs</strong></summary><ol>"
+            for epoch_index in range(self.get_num_epochs()):
+                samples = self.get_num_samples(epoch_index)
+                duration = self.get_duration(epoch_index)
+                memory_size = self.get_memory_size(epoch_index)
                 samples_str = f"{samples:,}"
                 duration_str = convert_seconds_to_str(duration)
                 memory_size_str = convert_bytes_to_str(memory_size)
-                html_segments += (
-                    f"<li> Samples: {samples_str}, Duration: {duration_str}, Memory: {memory_size_str}</li>"
-                )
+                html_epochs += f"<li> Samples: {samples_str}, Duration: {duration_str}, Memory: {memory_size_str}</li>"
 
-            html_segments += "</ol></details>"
+            html_epochs += "</ol></details>"
 
         html_extra = self._get_common_repr_html(common_style)
         # remove properties from html_extra
@@ -109,7 +107,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
                 # Find the end of that details section
                 details_end = html_extra.find("</details>", properties_start) + len("</details>")
                 html_extra = html_extra[:details_start] + html_extra[details_end:]
-        html_repr = html_header + html_segments + html_extra
+        html_repr = html_header + html_epochs + html_extra
         return html_repr
 
     @property
@@ -156,6 +154,27 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         """
         return len(self.plane_ids)
 
+    @property
+    def epochs(self):
+        """Get the epochs (segments) of the imaging data.
+
+        Returns
+        -------
+        list
+            A list of epochs (segments) in the imaging data.
+        """
+        return self.segments
+
+    def add_epoch(self, epoch: "BaseImagingEpoch"):
+        """Add an epoch (segment) to the imaging data.
+
+        Parameters
+        ----------
+        epoch : BaseImagingEpoch
+            The epoch (segment) to add to the imaging data.
+        """
+        self.add_segment(epoch)
+
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
@@ -164,6 +183,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
 
     def get_shape(self, segment_index: int | None = None) -> tuple:
         """Get the shape of the imaging data as (num_samples, height, width, planes).
+        Used internally for SpikeInterface chunk processing.
 
         Parameters
         ----------
@@ -176,7 +196,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             The shape of the imaging data as (num_samples, height, width, planes).
         """
         if segment_index is None:
-            if self.get_num_segments() == 1:
+            if self.get_num_epochs() == 1:
                 segment_index = 0
             else:
                 raise ValueError("segment_index must be provided for multi-segment imaging data.")
@@ -185,7 +205,23 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         return (num_samples, *self.shape)
 
     def get_data(self, start_frame: int, end_frame: int, segment_index: int | None = None, **kwargs) -> np.ndarray:
-        return self.get_series(start_frame=start_frame, end_frame=end_frame, segment_index=segment_index)
+        """Internal function to return data for SpikeInterface chunk processing.
+
+        Parameters
+        ----------
+        start_frame : int
+            The starting frame index (inclusive).
+        end_frame : int
+            The ending frame index (exclusive).
+        segment_index : int | None, optional
+            The index of the imaging segment. If None and there is only one segment, it defaults to 0.
+
+        Returns
+        -------
+        np.ndarray
+            The requested series of frames as a NumPy array, with shape (num_samples, height, width, planes).
+        """
+        return self.get_series(start_frame=start_frame, end_frame=end_frame, epoch_index=segment_index)
 
     def get_num_samples(self, segment_index: int | None = None) -> int:
         """Get the number of samples (frames) in the imaging segment.
@@ -200,23 +236,13 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             The number of samples (frames) in the segment.
         """
         if segment_index is None:
-            if self.get_num_segments() == 1:
+            if self.get_num_epochs() == 1:
                 segment_index = 0
             else:
                 raise ValueError("segment_index must be provided for multi-segment imaging data.")
         return self.segments[segment_index].get_num_samples()
 
-    def get_total_samples(self) -> int:
-        """Get the total number of samples (frames) across all segments.
-
-        Returns
-        -------
-        int
-            The total number of samples (frames) across all segments.
-        """
-        return sum(self.get_num_samples(segment_index=i) for i in range(self.get_num_segments()))
-
-    def get_num_frames(self, segment_index: int | None = None) -> int:
+    def get_num_frames(self, epoch_index: int | None = None) -> int:
         """Get the total number of frames in the imaging data.
 
         Parameters
@@ -227,15 +253,37 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         int
             The total number of frames.
         """
-        return self.get_num_samples(segment_index=segment_index)
+        return self.get_num_samples(segment_index=epoch_index)
 
-    def get_num_segments(self) -> int:
+    def get_total_frames(self) -> int:
+        """Get the total number of frames across all segments.
+
+        Returns
+        -------
+        int
+            The total number of frames across all segments.
+        """
+        return self.get_total_samples()
+
+    def get_num_segments(self) -> int:  # pragma: no cover
         """Get the number of imaging segments.
+        This is needed for SpikeInterface compatibility, but the photon-mosaic nomenclature is
+        "epochs" instead. Use `get_num_epochs()` is preferred.
 
         Returns
         -------
         int
             The number of imaging segments.
+        """
+        return len(self.segments)
+
+    def get_num_epochs(self) -> int:
+        """Get the number of imaging epochs.
+
+        Returns
+        -------
+        int
+            The number of imaging epochs.
         """
         return len(self.segments)
 
@@ -247,7 +295,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         dtype: dtype
             Data type of the video.
         """
-        return self.get_series(start_frame=0, end_frame=2, segment_index=0).dtype
+        return self.get_series(start_frame=0, end_frame=2, epoch_index=0).dtype
 
     def get_num_pixels(self) -> int:
         """Get the number of pixels in the image.
@@ -274,7 +322,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         start_frame: int | None = None,
         end_frame: int | None = None,
         plane_ids: list[int] | None = None,
-        segment_index: int | None = None,
+        epoch_index: int | None = None,
     ) -> np.ndarray:
         """Get a series of frames from the imaging data.
 
@@ -286,7 +334,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             The ending frame index (exclusive).
         plane_ids : list[int] | None
             The list of plane IDs to include. If None, all planes are included.
-        segment_index : int | None
+        epoch_index : int | None
             The index of the imaging segment. If None and there is only one segment, it defaults to 0.
 
         Returns
@@ -294,18 +342,18 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         np.ndarray
             The requested series of frames as a NumPy array.
         """
-        if segment_index is None:
-            if self.get_num_segments() == 1:
-                segment_index = 0
+        if epoch_index is None:
+            if self.get_num_epochs() == 1:
+                epoch_index = 0
             else:
-                raise ValueError("segment_index must be provided for multi-segment imaging data.")
+                raise ValueError("epoch_index must be provided for multi-segment imaging data.")
         start_frame = start_frame if start_frame is not None else 0
-        end_frame = end_frame if end_frame is not None else self.get_num_samples(segment_index=segment_index)
+        end_frame = end_frame if end_frame is not None else self.get_num_frames(epoch_index=epoch_index)
         if plane_ids is None:
             plane_indices = range(self.get_num_planes())
         else:
             plane_indices = self.ids_to_indices(plane_ids)
-        return self.segments[segment_index].get_series(start_frame, end_frame, plane_indices)
+        return self.epochs[epoch_index].get_series(start_frame, end_frame, plane_indices)
 
     def get_average_image(
         self,
@@ -375,7 +423,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
 
         if format == "binary":
             folder = kwargs["folder"]
-            file_paths = [folder / f"video_cached_seg{i}.raw" for i in range(self.get_num_segments())]
+            file_paths = [folder / f"video_cached_seg{i}.raw" for i in range(self.get_num_epochs())]
             dtype = kwargs.get("dtype", None) or self.get_dtype()
             t_starts = self._get_t_starts()
 
@@ -407,18 +455,18 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         else:
             raise ValueError(f"format {format} not supported")
 
-        for segment_index in range(self.get_num_segments()):
-            if self.has_time_vector(segment_index):
+        for epoch_index in range(self.get_num_epochs()):
+            if self.has_time_vector(epoch_index):
                 # the use of get_times is preferred since timestamps are converted to array
-                time_vector = self.get_times(segment_index=segment_index)
-                cached.set_times(time_vector, segment_index=segment_index)
+                time_vector = self.get_times(segment_index=epoch_index)
+                cached.set_times(time_vector, segment_index=epoch_index)
 
         return cached
 
 
-class BaseImagingSegment(ChunkableSegment):
+class BaseImagingEpoch(ChunkableSegment):
     """
-    Abstract class representing a multichannel timeseries, or block of raw ephys traces
+    Abstract class representing a video epoch.
     """
 
     def get_series(

--- a/src/photon_mosaic/core/baserois.py
+++ b/src/photon_mosaic/core/baserois.py
@@ -22,7 +22,7 @@ class BaseRois(BaseExtractor):
         self._num_planes = shape[2]
         self._roi_ids = np.array(roi_ids)
         self._imaging: BaseImaging | None = None
-        # no concept of segments for rois, since they are spatial only
+        # no concept of epochs for rois, since they are spatial only
 
     def __repr__(self):
         return self._repr_header()
@@ -72,16 +72,6 @@ class BaseRois(BaseExtractor):
             True if an imaging is registered, False otherwise.
         """
         return self._imaging is not None
-
-    def get_num_segments(self) -> int:
-        """Get the number of segments. Always 1 for BaseRois.
-
-        Returns
-        -------
-        int
-            The number of segments (always 1 for BaseRois).
-        """
-        return 1
 
     @property
     def shape(self):
@@ -209,7 +199,7 @@ class BaseRois(BaseExtractor):
         Parameters
         ----------
         imaging : BaseImaging
-            Imaging with the same number of segments as current sorting.
+            Imaging with the same number of planes as the ROIs.
             Assigned to self._imaging.
         """
         assert (

--- a/src/photon_mosaic/core/binaryimaging.py
+++ b/src/photon_mosaic/core/binaryimaging.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import numpy as np
 
-from .baseimaging import BaseImaging, BaseImagingSegment
+from .baseimaging import BaseImaging, BaseImagingEpoch
 
 
 class BinaryImaging(BaseImaging):
@@ -29,7 +29,7 @@ class BinaryImaging(BaseImaging):
     time_axis : int, default: 0
         The axis of the time dimension
     t_starts : None or list of float, default: None
-        Times in seconds of the first sample for each segment
+        Times in seconds of the first sample for each epoch. If None, defaults to 0 for all epochs.
     file_offset : int, default: 0
         Number of bytes in the file to offset by during memmap instantiation.
 
@@ -51,10 +51,10 @@ class BinaryImaging(BaseImaging):
         BaseImaging.__init__(self, sampling_frequency, shape)
 
         if isinstance(file_paths, list):
-            # several segment
+            # several epochs
             file_path_list = [Path(p) for p in file_paths]
         else:
-            # one segment
+            # one epoch
             file_path_list = [Path(file_paths)]
 
         if t_starts is not None:
@@ -68,7 +68,7 @@ class BinaryImaging(BaseImaging):
                 t_start = None
             else:
                 t_start = t_starts[i]
-            imaging_segment = BinaryImagingSegment(
+            imaging_epoch = BinaryImagingEpoch(
                 file_path,
                 sampling_frequency,
                 t_start,
@@ -76,7 +76,7 @@ class BinaryImaging(BaseImaging):
                 dtype,
                 file_offset,
             )
-            self.add_segment(imaging_segment)
+            self.add_epoch(imaging_epoch)
 
         self._kwargs = {
             "file_paths": [str(Path(e).absolute()) for e in file_path_list],
@@ -101,20 +101,20 @@ class BinaryImaging(BaseImaging):
 
     def __del__(self):  # pragma: no cover
         """
-        Ensures that all segment resources are properly cleaned up when this imaging extractor is deleted.
-        Closes any open file handles in the imaging segments.
+        Ensures that all epoch resources are properly cleaned up when this imaging extractor is deleted.
+        Closes any open file handles in the imaging epochs.
         """
-        # Close all imaging segments
-        if hasattr(self, "_segments"):
-            for segment in self.segments:
-                # This will trigger the __del__ method of the BinaryImagingSegment
+        # Close all imaging epochs
+        if hasattr(self, "epochs"):
+            for epoch in self.epochs:
+                # This will trigger the __del__ method of the BaseImagingEpoch
                 # which will close the file handle
-                del segment
+                del epoch
 
 
-class BinaryImagingSegment(BaseImagingSegment):
+class BinaryImagingEpoch(BaseImagingEpoch):
     def __init__(self, file_path, sampling_frequency, t_start, shape, dtype, file_offset):
-        BaseImagingSegment.__init__(self, sampling_frequency=sampling_frequency, t_start=t_start)
+        BaseImagingEpoch.__init__(self, sampling_frequency=sampling_frequency, t_start=t_start)
         self.shape = shape
         self.dtype = np.dtype(dtype)
         self.file_offset = file_offset
@@ -188,12 +188,12 @@ class BinaryImagingSegment(BaseImagingSegment):
         return series
 
     def __del__(self):  # pragma: no cover
-        # Ensure that the file handle is closed when the segment is garbage-collected
+        # Ensure that the file handle is closed when the epoch is garbage-collected
         try:
             if hasattr(self, "file") and self.file and not self.file.closed:
                 self.file.close()
         except Exception as e:
-            warnings.warn(f"Error closing file handle in BinaryImagingSegment: {e}")
+            warnings.warn(f"Error closing file handle in BaseImagingEpoch: {e}")
             pass
 
 

--- a/src/photon_mosaic/core/generators.py
+++ b/src/photon_mosaic/core/generators.py
@@ -19,7 +19,7 @@ def generate_random_imaging(
     Parameters
     ----------
     num_frames : int | tuple[int, ...], default: 1000
-        Number of frames for each segment in the imaging data.
+        Number of frames for each epoch in the imaging data.
     height : int, default: 256
         Height of each frame in pixels.
     width : int, default: 256

--- a/src/photon_mosaic/core/numpyimaging.py
+++ b/src/photon_mosaic/core/numpyimaging.py
@@ -1,22 +1,22 @@
-"""Imaging and Segmentation Extractors for in-memory numpy arrays.
+"""Imaging and ROI classes for in-memory numpy arrays.
 
 Classes
 -------
-NumpyImagingExtractor
-    An ImagingExtractor specified by timeseries .npy file, sampling frequency, and channel names.
-NumpySegmentationExtractor
-    A Segmentation extractor specified by image masks and traces .npy files.
+NumpyImaging
+    An Imaging specified by timeseries .npy file, sampling frequency, and channel names.
+NumpyRois
+    A ROIs specified by image masks and traces .npy files.
 """
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-from .baseimaging import BaseImaging, BaseImagingSegment
+from .baseimaging import BaseImaging, BaseImagingEpoch
 from .baserois import BaseRois
 
 
 class NumpyImaging(BaseImaging):
-    """An single-segment or multi-segment Imaging specified by a numpy array or list of arrays"""
+    """An single- or multi-epoch Imaging specified by a numpy array or list of arrays"""
 
     def __init__(
         self,
@@ -27,8 +27,8 @@ class NumpyImaging(BaseImaging):
     ):
         """Create a NumpyImagingExtractor from a numpy array or list of numpy arrays.
 
-        If a list of numpy arrays is provided, each array is treated as a separate segment.
-        Individual segments can have one or more planes. In the former case, the shape of each
+        If a list of numpy arrays is provided, each array is treated as a separate epoch.
+        Individual epochs can have one or more planes. In the former case, the shape of each
         array should be (num_frames, height, width). In the latter case, the shape should be
         (num_frames, height, width, num_planes).
 
@@ -48,10 +48,10 @@ class NumpyImaging(BaseImaging):
         else:
             raise ValueError("'timeseries' must be a numpy array or a list of numpy arrays")
 
-        num_segments = len(videos)
+        num_epochs = len(videos)
         self._sampling_frequency = float(sampling_frequency)
 
-        # Check that all shapes and number of planes are consistent across segments
+        # Check that all shapes and number of planes are consistent across epochs
         shapes = []
         for video in videos:
             if len(video.shape) not in [3, 4]:
@@ -62,21 +62,20 @@ class NumpyImaging(BaseImaging):
                 video = video[:, :, :, np.newaxis]  # Add a planes dimension
             shapes.append(video.shape[1:])
         if not all(shape == shapes[0] for shape in shapes):
-            raise ValueError("All segments must have the same image shape (height, width, planes)")
+            raise ValueError("All epochs must have the same image shape (height, width, planes)")
 
         # Check consistency of time vectors
         if time_vectors is not None:
-            if num_segments == 1 and isinstance(time_vectors, np.ndarray):
+            if num_epochs == 1 and isinstance(time_vectors, np.ndarray):
                 time_vectors = [time_vectors]
-            assert len(time_vectors) == num_segments, "Number of time vectors must match number of segments"
+            assert len(time_vectors) == num_epochs, "Number of time vectors must match number of epochs"
         else:
-            time_vectors = [None] * num_segments
-
+            time_vectors = [None] * num_epochs
         BaseImaging.__init__(self, shape=shapes[0], sampling_frequency=sampling_frequency)
 
         for video, time_vector in zip(videos, time_vectors):
-            self.add_segment(
-                NumpyImagingSegment(
+            self.add_epoch(
+                NumpyImagingEpoch(
                     video=video,
                     sampling_frequency=self._sampling_frequency,
                     time_vector=time_vector,
@@ -91,8 +90,8 @@ class NumpyImaging(BaseImaging):
         }
 
 
-class NumpyImagingSegment(BaseImagingSegment):
-    """A single segment of an Imaging specified by a numpy array"""
+class NumpyImagingEpoch(BaseImagingEpoch):
+    """A single epoch of an Imaging specified by a numpy array"""
 
     def __init__(
         self,
@@ -127,10 +126,12 @@ class NumpyImagingSegment(BaseImagingSegment):
         return self._video[start:end, :, :, plane_indices] if plane_indices is not None else self._video[start:end]
 
     def get_num_samples(self) -> int:
-        """Returns the number of samples in this signal segment
+        """Returns the number of samples in this signal epoch
 
-        Returns:
-            SampleIndex : Number of samples in the signal segment
+        Returns
+        -------
+        int
+            Number of samples in the signal epoch
         """
         return self._video.shape[0]
 

--- a/src/photon_mosaic/core/tests/test_baseimaging.py
+++ b/src/photon_mosaic/core/tests/test_baseimaging.py
@@ -9,7 +9,7 @@ def test_random_imaging_basic_properties():
     num_frames, h, w, sf = 10, 8, 9, 30.0
     imaging = generate_random_imaging(num_frames=num_frames, height=h, width=w, sampling_frequency=sf, seed=0)
 
-    assert imaging.get_num_segments() == 1
+    assert imaging.get_num_epochs() == 1
     assert imaging.get_num_frames() == num_frames
     assert imaging.get_num_samples() == num_frames
     assert tuple(imaging.shape) == (h, w, 1)
@@ -85,7 +85,7 @@ def test_random_imaging_repr_contains_expected_fields():
     s = repr(imaging)
     assert "rows x" in s
     assert "columns" in s
-    assert "segments" in s
+    assert "epochs" in s
     assert "dtype" in s
     assert "Hz" in s
 
@@ -103,7 +103,7 @@ def test_random_imaging_repr_contains_expected_fields():
     s_html = imaging._repr_html_()
     assert "rows x" in s_html
     assert "columns" in s_html
-    assert "segments" in s_html
+    assert "epochs" in s_html
     assert "dtype" in s_html
     assert "Hz" in s_html
 
@@ -116,13 +116,13 @@ def test_baseimaging_constructor_with_2d_dhape():
     assert base_imaging.shape == (50, 50, 1)
 
 
-def test_baseimaging_multi_segment_requires_segment_index():
+def test_baseimaging_multi_epoch_requires_epoch_index():
     sf = 10.0
     h, w = 3, 4
     num_frames = [10, 20]
     imaging = generate_random_imaging(num_frames=num_frames, height=h, width=w, sampling_frequency=sf, seed=5)
 
-    assert imaging.get_num_segments() == 2
+    assert imaging.get_num_epochs() == 2
 
     with pytest.raises(ValueError):
         _ = imaging.get_num_samples()
@@ -133,16 +133,15 @@ def test_baseimaging_multi_segment_requires_segment_index():
     with pytest.raises(ValueError):
         _ = imaging.get_shape()
 
-    # Works when segment_index is provided
-    assert imaging.get_num_samples(segment_index=0) == 10
-    assert imaging.get_num_samples(segment_index=1) == 20
-    assert imaging.get_total_samples() == 30
-    assert imaging.get_series(segment_index=1).shape == (20, h, w, 1)
+    # Works when epoch_index is provided
+    assert imaging.get_num_frames(epoch_index=0) == 10
+    assert imaging.get_num_frames(epoch_index=1) == 20
+    assert imaging.get_total_frames() == 30
+    assert imaging.get_series(epoch_index=1).shape == (20, h, w, 1)
     assert imaging.get_shape(segment_index=0) == (10, h, w, 1)
-
     # Run repr_html
     str_html = imaging._repr_html_()
-    assert "segments" in str_html
+    assert "epochs" in str_html
 
 
 def test_get_average_image_caches_and_recompute_replaces():
@@ -176,7 +175,7 @@ def test_multiplane_basic_shape_and_plane_ids():
         seed=0,
     )
 
-    assert imaging.get_num_segments() == 1
+    assert imaging.get_num_epochs() == 1
     assert imaging.get_num_planes() == p and imaging.num_planes == p
     assert np.array_equal(imaging.plane_ids, list(range(p)))
     assert imaging.get_shape() == (n, h, w, p)

--- a/src/photon_mosaic/core/tests/test_baserois.py
+++ b/src/photon_mosaic/core/tests/test_baserois.py
@@ -53,7 +53,6 @@ def test_init_stores_sampling_frequency_shape_and_roi_ids(make_rois_for_tests):
     assert np.all(np.asarray(rois.shape) == np.array([roi_kwargs["height"], roi_kwargs["width"], 1]))
     assert np.all(np.asarray(rois.roi_ids) == np.array(roi_kwargs["roi_ids"]))
     assert rois.get_num_rois() == roi_kwargs["num_rois"]
-    assert rois.get_num_segments() == 1
     assert rois.imaging is None
     assert rois.has_imaging() is False
 

--- a/src/photon_mosaic/core/tests/test_binaryimaging.py
+++ b/src/photon_mosaic/core/tests/test_binaryimaging.py
@@ -16,7 +16,7 @@ def _write_binary_file(path: Path, array: np.ndarray, file_offset: int = 0) -> N
         f.write(array.tobytes(order="C"))
 
 
-def test_binaryimaging_single_segment_single_plane_roundtrip(tmp_path: Path):
+def test_binaryimaging_single_epoch_single_plane_roundtrip(tmp_path: Path):
     n_frames, h, w = 11, 3, 4
     dtype = np.uint16
     data = np.arange(n_frames * h * w, dtype=dtype).reshape(n_frames, h, w, 1)
@@ -31,7 +31,7 @@ def test_binaryimaging_single_segment_single_plane_roundtrip(tmp_path: Path):
         dtype=dtype,
     )
 
-    assert imaging.get_num_segments() == 1
+    assert imaging.get_num_epochs() == 1
     assert imaging.get_num_frames() == n_frames
     assert tuple(imaging.shape) == (h, w, 1)
     assert imaging.is_binary_compatible()
@@ -101,7 +101,7 @@ def test_binaryimaging_with_tstarts(tmp_path: Path):
         t_starts=t_starts,
     )
 
-    assert imaging.get_num_segments() == 2
+    assert imaging.get_num_epochs() == 2
 
     time_vector_0 = imaging.get_times(segment_index=0)
     expected_time_0 = np.arange(4) / 10.0 + t_starts[0]
@@ -112,7 +112,7 @@ def test_binaryimaging_with_tstarts(tmp_path: Path):
     np.testing.assert_allclose(time_vector_1, expected_time_1)
 
 
-def test_binaryimaging_multiple_segments(tmp_path: Path):
+def test_binaryimaging_multiple_epochs(tmp_path: Path):
     h, w = 3, 3
     dtype = np.uint8
 
@@ -131,12 +131,12 @@ def test_binaryimaging_multiple_segments(tmp_path: Path):
         dtype=dtype,
     )
 
-    assert imaging.get_num_segments() == 2
-    assert imaging.get_num_samples(segment_index=0) == 5
-    assert imaging.get_num_samples(segment_index=1) == 8
+    assert imaging.get_num_epochs() == 2
+    assert imaging.get_num_frames(epoch_index=0) == 5
+    assert imaging.get_num_frames(epoch_index=1) == 8
 
-    s0 = imaging.get_series(0, 5, segment_index=0)
-    s1 = imaging.get_series(0, 8, segment_index=1)
+    s0 = imaging.get_series(0, 5, epoch_index=0)
+    s1 = imaging.get_series(0, 8, epoch_index=1)
     np.testing.assert_array_equal(s0, data0)
     np.testing.assert_array_equal(s1, data1)
 
@@ -210,7 +210,7 @@ def test_baseimaging_save_binary_with_multiprocessing(tmp_path: Path):
         BinaryFolderImaging(bad_folder)
 
 
-def test_base_imaging_multi_segment_multiplane_save(tmp_path: Path):
+def test_base_imaging_multi_epoch_multiplane_save(tmp_path: Path):
     n = (15, 30)
     h, w, p = 5, 5, 3
     sf = 20.0
@@ -235,12 +235,10 @@ def test_base_imaging_multi_segment_multiplane_save(tmp_path: Path):
     loaded = BinaryFolderImaging(out_folder)
     assert loaded.get_num_planes() == p
 
-    assert imaging.get_num_segments() == loaded.get_num_segments()
-    for segment_index in range(imaging.get_num_segments()):
-        assert imaging.get_num_samples(segment_index=segment_index) == loaded.get_num_samples(
-            segment_index=segment_index
-        )
-        full = imaging.get_series(segment_index=segment_index)
-        got = loaded.get_series(segment_index=segment_index)
+    assert imaging.get_num_epochs() == loaded.get_num_epochs()
+    for epoch_index in range(imaging.get_num_epochs()):
+        assert imaging.get_num_frames(epoch_index=epoch_index) == loaded.get_num_frames(epoch_index=epoch_index)
+        full = imaging.get_series(epoch_index=epoch_index)
+        got = loaded.get_series(epoch_index=epoch_index)
         assert got.shape == full.shape
         np.testing.assert_array_equal(got, full)

--- a/src/photon_mosaic/core/tests/test_generators.py
+++ b/src/photon_mosaic/core/tests/test_generators.py
@@ -11,14 +11,14 @@ def test_generate_random_imaging_int_vs_singleton_tuple_same_output():
     imaging_int = generate_random_imaging(num_frames=n, height=h, width=w, sampling_frequency=sf, seed=seed)
     imaging_tuple = generate_random_imaging(num_frames=(n,), height=h, width=w, sampling_frequency=sf, seed=seed)
 
-    assert imaging_int.get_num_segments() == 1
-    assert imaging_tuple.get_num_segments() == 1
+    assert imaging_int.get_num_epochs() == 1
+    assert imaging_tuple.get_num_epochs() == 1
 
     np.testing.assert_array_equal(imaging_int.get_series(), imaging_tuple.get_series())
     assert imaging_int.get_shape() == imaging_tuple.get_shape() == (n, h, w, 1)
 
 
-def test_generate_random_imaging_multisegment_shapes_and_reproducibility_multiplane():
+def test_generate_random_imaging_multiepoch_shapes_and_reproducibility_multiplane():
     num_frames = (3, 5)
     h, w, p = 4, 6, 2
     sf = 12.5
@@ -41,16 +41,16 @@ def test_generate_random_imaging_multisegment_shapes_and_reproducibility_multipl
         seed=seed,
     )
 
-    assert imaging1.get_num_segments() == 2
+    assert imaging1.get_num_epochs() == 2
     assert imaging1.get_num_planes() == p
 
-    s10 = imaging1.get_series(segment_index=0)
-    s11 = imaging1.get_series(segment_index=1)
+    s10 = imaging1.get_series(epoch_index=0)
+    s11 = imaging1.get_series(epoch_index=1)
     assert s10.shape == (num_frames[0], h, w, p)
     assert s11.shape == (num_frames[1], h, w, p)
 
-    np.testing.assert_allclose(imaging1.get_series(segment_index=0), imaging2.get_series(segment_index=0))
-    np.testing.assert_allclose(imaging1.get_series(segment_index=1), imaging2.get_series(segment_index=1))
+    np.testing.assert_allclose(imaging1.get_series(epoch_index=0), imaging2.get_series(epoch_index=0))
+    np.testing.assert_allclose(imaging1.get_series(epoch_index=1), imaging2.get_series(epoch_index=1))
 
 
 def test_generate_random_imaging_num_planes_1_returns_3d_series():

--- a/src/photon_mosaic/core/tests/test_numpyimaging.py
+++ b/src/photon_mosaic/core/tests/test_numpyimaging.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from photon_mosaic.core.numpyimaging import NumpyImaging, NumpyImagingSegment, NumpyRois
+from photon_mosaic.core.numpyimaging import NumpyImaging, NumpyImagingEpoch, NumpyRois
 
 
 def test_numpyimaging_rejects_invalid_imaging_series_type():
@@ -18,16 +18,16 @@ def test_numpyimaging_accepts_single_3d_array_and_wraps_time_vector():
     assert isinstance(im._sampling_frequency, float)
     assert im._sampling_frequency == 10.0
 
-    # time_vectors ndarray should be wrapped into a list for a single segment
+    # time_vectors ndarray should be wrapped into a list for a single epoch
     assert "time_vectors" in im._kwargs
     assert isinstance(im._kwargs["time_vectors"], list)
     assert len(im._kwargs["time_vectors"]) == 1
     np.testing.assert_allclose(im._kwargs["time_vectors"][0], t)
 
-    assert len(im.segments) == 1
+    assert len(im.epochs) == 1
 
 
-def test_numpyimaging_defaults_time_vectors_to_none_per_segment():
+def test_numpyimaging_defaults_time_vectors_to_none_per_epoch():
     v1 = np.zeros((3, 4, 5), dtype=np.uint8)
     v2 = np.zeros((7, 4, 5), dtype=np.uint8)
 
@@ -36,7 +36,7 @@ def test_numpyimaging_defaults_time_vectors_to_none_per_segment():
     assert isinstance(im._kwargs["time_vectors"], list)
     assert im._kwargs["time_vectors"] == [None, None]
 
-    assert len(im.segments) == 2
+    assert len(im.epochs) == 2
 
 
 def test_numpyimaging_rejects_non_3d_or_4d_videos():
@@ -50,7 +50,7 @@ def test_numpyimaging_rejects_non_3d_or_4d_videos():
         NumpyImaging(imaging_series=bad5d, sampling_frequency=1.0)
 
 
-def test_numpyimaging_rejects_inconsistent_shapes_across_segments():
+def test_numpyimaging_rejects_inconsistent_shapes_across_epochs():
     v1 = np.zeros((5, 8, 9), dtype=np.float32)
     v2 = np.zeros((5, 8, 10), dtype=np.float32)  # different width
 
@@ -58,7 +58,7 @@ def test_numpyimaging_rejects_inconsistent_shapes_across_segments():
         NumpyImaging(imaging_series=[v1, v2], sampling_frequency=10.0)
 
 
-def test_numpyimaging_time_vectors_length_must_match_num_segments():
+def test_numpyimaging_time_vectors_length_must_match_num_epochs():
     v1 = np.zeros((5, 8, 9), dtype=np.float32)
     v2 = np.zeros((6, 8, 9), dtype=np.float32)
 
@@ -70,15 +70,15 @@ def test_numpyimaging_time_vectors_length_must_match_num_segments():
 # Plane ids argument has been removed
 
 
-def test_numpyimagingsegment_get_num_samples():
+def test_numpyimagingepoch_get_num_samples():
     video = np.zeros((11, 2, 3), dtype=np.float32)
-    seg = NumpyImagingSegment(video=video, sampling_frequency=5.0)
+    seg = NumpyImagingEpoch(video=video, sampling_frequency=5.0)
     assert seg.get_num_samples() == 11
 
 
-def test_numpyimagingsegment_get_series_3d_basic_slicing():
+def test_numpyimagingepoch_get_series_3d_basic_slicing():
     video = np.arange(5 * 3 * 4, dtype=np.int32).reshape(5, 3, 4, 1)
-    seg = NumpyImagingSegment(video=video, sampling_frequency=1.0)
+    seg = NumpyImagingEpoch(video=video, sampling_frequency=1.0)
 
     out_all = seg.get_series()
     np.testing.assert_array_equal(out_all, video)
@@ -91,9 +91,9 @@ def test_numpyimagingsegment_get_series_3d_basic_slicing():
     np.testing.assert_array_equal(out_pi, video[0:2, ...])
 
 
-def test_numpyimagingsegment_get_series_4d_plane_selection():
+def test_numpyimagingepoch_get_series_4d_plane_selection():
     video = np.arange(6 * 2 * 3 * 4, dtype=np.int32).reshape(6, 2, 3, 4)
-    seg = NumpyImagingSegment(video=video, sampling_frequency=1.0)
+    seg = NumpyImagingEpoch(video=video, sampling_frequency=1.0)
 
     out_all = seg.get_series()
     np.testing.assert_array_equal(out_all, video)


### PR DESCRIPTION
Some `segment_index` need to stay for SpikeInterface cmpatibility, but high level functions can use epochs and frames (preferred to segment/sample)

Fixes #15 