### PR TITLE
`ZarrImaging` and `save(format="zarr")`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
-    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@f6fbef9d7f30dcaba561f4590119fe9707823293",
+    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@793aab6ab9daa1becd9c5347f34afcae67275a8c",
     "roiextractors"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
-    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@564b123ce714c614cf164bd1b74c08913102d23d",
+    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@f6fbef9d7f30dcaba561f4590119fe9707823293",
     "roiextractors"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
-    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@7d6031e4af6c52741518afd3baf834dc55abc087",
+    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@564b123ce714c614cf164bd1b74c08913102d23d",
     "roiextractors"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
-    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@04f44e85ca848722bc60447aeadb5178c70c652b",
+    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@7d6031e4af6c52741518afd3baf834dc55abc087",
     "roiextractors"
 ]
 

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -455,7 +455,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             zarr_path = kwargs["zarr_path"]
             storage_options = kwargs.get("storage_options", None)
             zarr_root = zarr.open(str(zarr_path), mode="w", storage_options=storage_options)
-            add_imaging_to_zarr_group(self, zarr_root, **kwargs)
+            add_imaging_to_zarr_group(self, zarr_root, **kwargs, **job_kwargs)
 
             cached = ZarrImaging(zarr_path)
         elif format == "nwb":

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -5,7 +5,7 @@ from numpy.typing import ArrayLike, DTypeLike
 from spikeinterface.core.base import BaseExtractor
 from spikeinterface.core.chunkable import ChunkableMixin, ChunkableSegment
 from spikeinterface.core.chunkable_tools import get_chunks, write_binary
-from spikeinterface.core.core_tools import convert_bytes_to_str, convert_seconds_to_str
+from spikeinterface.core.core_tools import convert_bytes_to_str, convert_seconds_to_str, retrieve_importing_provenance
 
 
 class BaseImaging(BaseExtractor, ChunkableMixin):
@@ -452,12 +452,13 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
 
             from .zarrimaging import ZarrImaging, add_imaging_to_zarr_group
 
-            folder_path = kwargs["folder"]
+            zarr_path = kwargs["zarr_path"]
             storage_options = kwargs.get("storage_options", None)
-            zarr_root = zarr.open(str(folder_path), mode="w", storage_options=storage_options)
+            zarr_root = zarr.open(str(zarr_path), mode="w", storage_options=storage_options)
             add_imaging_to_zarr_group(self, zarr_root, **kwargs)
+            zarr_root.attrs["provenance"] = retrieve_importing_provenance(ZarrImaging)
 
-            cached = ZarrImaging(zarr_root)
+            cached = ZarrImaging(zarr_path)
         elif format == "nwb":
             raise NotImplementedError
 

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -448,7 +448,16 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         elif format == "memory":
             raise NotImplementedError
         elif format == "zarr":
-            raise NotImplementedError
+            import zarr
+
+            from .zarrimaging import ZarrImaging, add_imaging_to_zarr_group
+
+            folder_path = kwargs["folder"]
+            storage_options = kwargs.get("storage_options", None)
+            zarr_root = zarr.open(str(folder_path), mode="w", storage_options=storage_options)
+            add_imaging_to_zarr_group(self, zarr_root, **kwargs)
+
+            cached = ZarrImaging(zarr_root)
         elif format == "nwb":
             raise NotImplementedError
 

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -5,7 +5,7 @@ from numpy.typing import ArrayLike, DTypeLike
 from spikeinterface.core.base import BaseExtractor
 from spikeinterface.core.chunkable import ChunkableMixin, ChunkableSegment
 from spikeinterface.core.chunkable_tools import get_chunks, write_binary
-from spikeinterface.core.core_tools import convert_bytes_to_str, convert_seconds_to_str, retrieve_importing_provenance
+from spikeinterface.core.core_tools import convert_bytes_to_str, convert_seconds_to_str
 
 
 class BaseImaging(BaseExtractor, ChunkableMixin):
@@ -456,7 +456,6 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
             storage_options = kwargs.get("storage_options", None)
             zarr_root = zarr.open(str(zarr_path), mode="w", storage_options=storage_options)
             add_imaging_to_zarr_group(self, zarr_root, **kwargs)
-            zarr_root.attrs["provenance"] = retrieve_importing_provenance(ZarrImaging)
 
             cached = ZarrImaging(zarr_path)
         elif format == "nwb":

--- a/src/photon_mosaic/core/testingtools.py
+++ b/src/photon_mosaic/core/testingtools.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from photon_mosaic.core.baseimaging import BaseImaging
+
+
+def assert_imaging_equal(imaging1: BaseImaging, imaging2: BaseImaging):
+    assert imaging1.sampling_frequency == imaging2.sampling_frequency
+    assert imaging1.shape == imaging2.shape
+    assert len(imaging1.epochs) == len(imaging2.epochs)
+    assert imaging1.get_num_epochs() == imaging2.get_num_epochs()
+    assert imaging1.get_num_planes() == imaging2.get_num_planes()
+    assert imaging1.shape == imaging2.shape
+    for epoch_index in range(imaging1.get_num_epochs()):
+        np.testing.assert_array_equal(
+            imaging1.get_series(epoch_index=epoch_index), imaging2.get_series(epoch_index=epoch_index)
+        )
+        # slice and assert
+        start = 2
+        end = 6
+        imaging1_slice = imaging1.get_series(start_frame=start, end_frame=end, epoch_index=epoch_index)
+        imaging2_slice = imaging2.get_series(start_frame=start, end_frame=end, epoch_index=epoch_index)
+        np.testing.assert_array_equal(
+            imaging1_slice,
+            imaging2_slice,
+        )
+        shape1 = imaging1.shape
+        assert imaging1_slice.shape == (end - start, shape1[0], shape1[1], shape1[2])
+        assert imaging2_slice.shape == (end - start, shape1[0], shape1[1], shape1[2])

--- a/src/photon_mosaic/core/tests/test_binaryimaging.py
+++ b/src/photon_mosaic/core/tests/test_binaryimaging.py
@@ -6,6 +6,7 @@ import pytest
 
 from photon_mosaic.core.binaryimaging import BinaryFolderImaging, BinaryImaging
 from photon_mosaic.core.generators import generate_random_imaging
+from photon_mosaic.core.testingtools import assert_imaging_equal
 
 
 def _write_binary_file(path: Path, array: np.ndarray, file_offset: int = 0) -> None:
@@ -224,7 +225,7 @@ def test_base_imaging_multi_epoch_multiplane_save(tmp_path: Path):
     )
 
     out_folder = tmp_path / "multiplane_binary"
-    _ = imaging.save(
+    imaging_saved = imaging.save(
         format="binary",
         folder=str(out_folder),
         n_jobs=1,
@@ -232,13 +233,6 @@ def test_base_imaging_multi_epoch_multiplane_save(tmp_path: Path):
         progress_bar=False,
     )
 
-    loaded = BinaryFolderImaging(out_folder)
-    assert loaded.get_num_planes() == p
-
-    assert imaging.get_num_epochs() == loaded.get_num_epochs()
-    for epoch_index in range(imaging.get_num_epochs()):
-        assert imaging.get_num_frames(epoch_index=epoch_index) == loaded.get_num_frames(epoch_index=epoch_index)
-        full = imaging.get_series(epoch_index=epoch_index)
-        got = loaded.get_series(epoch_index=epoch_index)
-        assert got.shape == full.shape
-        np.testing.assert_array_equal(got, full)
+    imaging_loaded = BinaryFolderImaging(out_folder)
+    assert_imaging_equal(imaging, imaging_saved)
+    assert_imaging_equal(imaging, imaging_loaded)

--- a/src/photon_mosaic/core/tests/test_zarrimaging.py
+++ b/src/photon_mosaic/core/tests/test_zarrimaging.py
@@ -7,15 +7,15 @@ from photon_mosaic.core.zarrimaging import ZarrImaging
 
 @pytest.fixture
 def imaging():
-    return generate_random_imaging(num_frames=[100, 20, 30], height=16, width=16, sampling_frequency=10.0, seed=3)
+    return generate_random_imaging(num_frames=[40, 20, 30], height=4, width=4, sampling_frequency=10.0, seed=3)
 
 
 @pytest.fixture
 def imaging_multi_plane():
     imaging = generate_random_imaging(
-        num_frames=[100, 20, 30], height=16, width=16, sampling_frequency=10.0, seed=3, num_planes=5
+        num_frames=[100, 20, 30], height=4, width=4, sampling_frequency=10.0, seed=3, num_planes=3
     )
-    imaging.set_property("depth", np.arange(100, 105))
+    imaging.set_property("depth", np.arange(100, 103))
     return imaging
 
 
@@ -32,7 +32,7 @@ def test_zarr_writing(imaging, tmp_path):
     assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
     assert imaging_zarr.shape == imaging.shape
     assert imaging_zarr_loaded.shape == imaging.shape
-    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 16, 16, 1)
+    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 4, 4, 1)
 
     for epoch_index in range(imaging.get_num_epochs()):
         np.testing.assert_array_equal(
@@ -61,7 +61,7 @@ def test_zarr_multi_plane_writing(imaging_multi_plane, tmp_path):
     assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
     assert imaging_zarr.shape == imaging.shape
     assert imaging_zarr_loaded.shape == imaging.shape
-    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 16, 16, 5)
+    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 4, 4, 3)
 
     for epoch_index in range(imaging.get_num_epochs()):
         np.testing.assert_array_equal(

--- a/src/photon_mosaic/core/tests/test_zarrimaging.py
+++ b/src/photon_mosaic/core/tests/test_zarrimaging.py
@@ -7,13 +7,22 @@ from photon_mosaic.core.zarrimaging import ZarrImaging
 
 @pytest.fixture
 def imaging():
-    return generate_random_imaging(num_frames=[100, 20, 30], height=4, width=4, sampling_frequency=10.0, seed=3)
+    return generate_random_imaging(num_frames=[100, 20, 30], height=16, width=16, sampling_frequency=10.0, seed=3)
+
+
+@pytest.fixture
+def imaging_multi_plane():
+    imaging = generate_random_imaging(
+        num_frames=[100, 20, 30], height=16, width=16, sampling_frequency=10.0, seed=3, num_planes=5
+    )
+    imaging.set_property("depth", np.arange(100, 105))
+    return imaging
 
 
 def test_zarr_writing(imaging, tmp_path):
     zarr_path = tmp_path / "test_imaging.zarr"
 
-    imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path, n_jobs=2)
 
     imaging_zarr_loaded = ZarrImaging(zarr_path)
 
@@ -23,6 +32,36 @@ def test_zarr_writing(imaging, tmp_path):
     assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
     assert imaging_zarr.shape == imaging.shape
     assert imaging_zarr_loaded.shape == imaging.shape
+    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 16, 16, 1)
+
+    for epoch_index in range(imaging.get_num_epochs()):
+        np.testing.assert_array_equal(
+            imaging_zarr.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
+        )
+        np.testing.assert_array_equal(
+            imaging_zarr_loaded.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
+        )
+
+    # load_compression_ratio
+    imaging_with_cr = ZarrImaging(zarr_path, load_compression_ratio=True)
+    assert "compression_ratio" in imaging_with_cr.get_annotation_keys()
+
+
+def test_zarr_multi_plane_writing(imaging_multi_plane, tmp_path):
+    zarr_path = tmp_path / "test_imaging.zarr"
+
+    imaging = imaging_multi_plane
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path, n_jobs=2)
+
+    imaging_zarr_loaded = ZarrImaging(zarr_path)
+
+    assert imaging_zarr_loaded.sampling_frequency == imaging.sampling_frequency
+    assert len(imaging_zarr_loaded.epochs) == len(imaging.epochs)
+    assert imaging_zarr.get_num_epochs() == imaging.get_num_epochs()
+    assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
+    assert imaging_zarr.shape == imaging.shape
+    assert imaging_zarr_loaded.shape == imaging.shape
+    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 16, 16, 5)
 
     for epoch_index in range(imaging.get_num_epochs()):
         np.testing.assert_array_equal(

--- a/src/photon_mosaic/core/tests/test_zarrimaging.py
+++ b/src/photon_mosaic/core/tests/test_zarrimaging.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from photon_mosaic.core.generators import generate_random_imaging
+from photon_mosaic.core.zarrimaging import ZarrImaging
+
+
+@pytest.fixture
+def imaging():
+    return generate_random_imaging(num_frames=[100, 20, 30], height=4, width=4, sampling_frequency=10.0, seed=3)
+
+
+def test_zarr_writing(imaging, tmp_path):
+    zarr_path = tmp_path / "test_imaging.zarr"
+
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
+
+    imaging_zarr_loaded = ZarrImaging(zarr_path)
+
+    assert imaging_zarr_loaded.sampling_frequency == imaging.sampling_frequency
+    assert len(imaging_zarr_loaded.epochs) == len(imaging.epochs)
+    assert imaging_zarr.get_num_epochs() == imaging.get_num_epochs()
+    assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
+    assert imaging_zarr.shape == imaging.shape
+    assert imaging_zarr_loaded.shape == imaging.shape
+
+    for epoch_index in range(imaging.get_num_epochs()):
+        np.testing.assert_array_equal(
+            imaging_zarr.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
+        )
+        np.testing.assert_array_equal(
+            imaging_zarr_loaded.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
+        )
+
+    # load_compression_ratio
+    imaging_with_cr = ZarrImaging(zarr_path, load_compression_ratio=True)
+    assert "compression_ratio" in imaging_with_cr.get_annotation_keys()
+
+
+def test_zarr_writing_with_t_starts(imaging, tmp_path):
+    t_starts = []
+    for epoch_index in range(imaging.get_num_segments()):
+        t_start = epoch_index * 10
+        imaging.shift_times(t_start, segment_index=epoch_index)
+        t_starts.append(t_start)
+
+    zarr_path = tmp_path / "test_imaging_t_starts.zarr"
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
+
+    for epoch_index in range(imaging_zarr.get_num_segments()):
+        assert imaging_zarr.get_start_time(epoch_index) == t_starts[epoch_index]
+
+
+def test_zarr_writing_with_times(imaging, tmp_path):
+    times_list = []
+    for epoch_index in range(imaging.get_num_segments()):
+        times = imaging.get_times(epoch_index) + epoch_index * 10 + 20
+        imaging.set_times(times, segment_index=epoch_index)
+        times_list.append(times)
+
+    zarr_path = tmp_path / "test_imaging_times.zarr"
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
+
+    for epoch_index in range(imaging_zarr.get_num_segments()):
+        np.testing.assert_array_equal(imaging_zarr.get_times(epoch_index), times_list[epoch_index])

--- a/src/photon_mosaic/core/tests/test_zarrimaging.py
+++ b/src/photon_mosaic/core/tests/test_zarrimaging.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from photon_mosaic.core.generators import generate_random_imaging
+from photon_mosaic.core.testingtools import assert_imaging_equal
 from photon_mosaic.core.zarrimaging import ZarrImaging
 
 
@@ -26,21 +27,8 @@ def test_zarr_writing(imaging, tmp_path):
 
     imaging_zarr_loaded = ZarrImaging(zarr_path)
 
-    assert imaging_zarr_loaded.sampling_frequency == imaging.sampling_frequency
-    assert len(imaging_zarr_loaded.epochs) == len(imaging.epochs)
-    assert imaging_zarr.get_num_epochs() == imaging.get_num_epochs()
-    assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
-    assert imaging_zarr.shape == imaging.shape
-    assert imaging_zarr_loaded.shape == imaging.shape
-    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 4, 4, 1)
-
-    for epoch_index in range(imaging.get_num_epochs()):
-        np.testing.assert_array_equal(
-            imaging_zarr.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
-        )
-        np.testing.assert_array_equal(
-            imaging_zarr_loaded.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
-        )
+    assert_imaging_equal(imaging, imaging_zarr)
+    assert_imaging_equal(imaging, imaging_zarr_loaded)
 
     # load_compression_ratio
     imaging_with_cr = ZarrImaging(zarr_path, load_compression_ratio=True)
@@ -55,21 +43,8 @@ def test_zarr_multi_plane_writing(imaging_multi_plane, tmp_path):
 
     imaging_zarr_loaded = ZarrImaging(zarr_path)
 
-    assert imaging_zarr_loaded.sampling_frequency == imaging.sampling_frequency
-    assert len(imaging_zarr_loaded.epochs) == len(imaging.epochs)
-    assert imaging_zarr.get_num_epochs() == imaging.get_num_epochs()
-    assert imaging_zarr_loaded.get_num_epochs() == imaging.get_num_epochs()
-    assert imaging_zarr.shape == imaging.shape
-    assert imaging_zarr_loaded.shape == imaging.shape
-    assert imaging_zarr_loaded.get_series(start_frame=2, end_frame=6, epoch_index=0).shape == (4, 4, 4, 3)
-
-    for epoch_index in range(imaging.get_num_epochs()):
-        np.testing.assert_array_equal(
-            imaging_zarr.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
-        )
-        np.testing.assert_array_equal(
-            imaging_zarr_loaded.get_series(epoch_index=epoch_index), imaging.get_series(epoch_index=epoch_index)
-        )
+    assert_imaging_equal(imaging, imaging_zarr)
+    assert_imaging_equal(imaging, imaging_zarr_loaded)
 
     # load_compression_ratio
     imaging_with_cr = ZarrImaging(zarr_path, load_compression_ratio=True)
@@ -78,7 +53,7 @@ def test_zarr_multi_plane_writing(imaging_multi_plane, tmp_path):
 
 def test_zarr_writing_with_t_starts(imaging, tmp_path):
     t_starts = []
-    for epoch_index in range(imaging.get_num_segments()):
+    for epoch_index in range(imaging.get_num_epochs()):
         t_start = epoch_index * 10
         imaging.shift_times(t_start, segment_index=epoch_index)
         t_starts.append(t_start)
@@ -86,13 +61,14 @@ def test_zarr_writing_with_t_starts(imaging, tmp_path):
     zarr_path = tmp_path / "test_imaging_t_starts.zarr"
     imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
 
-    for epoch_index in range(imaging_zarr.get_num_segments()):
+    for epoch_index in range(imaging_zarr.get_num_epochs()):
         assert imaging_zarr.get_start_time(epoch_index) == t_starts[epoch_index]
 
 
 def test_zarr_writing_with_times(imaging, tmp_path):
+    # Test all time vectors
     times_list = []
-    for epoch_index in range(imaging.get_num_segments()):
+    for epoch_index in range(imaging.get_num_epochs()):
         times = imaging.get_times(epoch_index) + epoch_index * 10 + 20
         imaging.set_times(times, segment_index=epoch_index)
         times_list.append(times)
@@ -100,5 +76,49 @@ def test_zarr_writing_with_times(imaging, tmp_path):
     zarr_path = tmp_path / "test_imaging_times.zarr"
     imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
 
-    for epoch_index in range(imaging_zarr.get_num_segments()):
+    for epoch_index in range(imaging_zarr.get_num_epochs()):
         np.testing.assert_array_equal(imaging_zarr.get_times(epoch_index), times_list[epoch_index])
+
+    # Test partial time vectors
+    imaging.reset_times()  # reset to default time vectors
+    for epoch_index in range(imaging.get_num_epochs()):
+        times = imaging.get_times(epoch_index) + epoch_index * 10 + 20
+        if epoch_index % 2 == 0:
+            imaging.set_times(times, segment_index=epoch_index)
+
+    zarr_path = tmp_path / "test_imaging_partial_times.zarr"
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path)
+
+    for epoch_index in range(imaging_zarr.get_num_epochs()):
+        assert imaging_zarr.has_time_vector(epoch_index) == imaging.has_time_vector(epoch_index)
+        np.testing.assert_array_equal(imaging_zarr.get_times(epoch_index), imaging.get_times(epoch_index))
+
+
+def test_zarr_writing_extra_chunks(imaging, tmp_path):
+    zarr_path = tmp_path / "test_imaging_extra_chunks.zarr"
+    imaging_zarr = imaging.save(format="zarr", folder=zarr_path, extra_chunks=(2, 2, 1))
+
+    imaging_zarr_loaded = ZarrImaging(zarr_path)
+
+    assert_imaging_equal(imaging, imaging_zarr)
+    assert_imaging_equal(imaging, imaging_zarr_loaded)
+
+    # check chunking
+    for epoch_index in range(imaging_zarr.get_num_epochs()):
+        chunk_shape = imaging_zarr._root[f"video_epoch{epoch_index}"].chunks
+        assert chunk_shape[1:] == (2, 2, 1)
+
+
+def test_zarr_writing_multi_plane_extra_chunks(imaging_multi_plane, tmp_path):
+    zarr_path = tmp_path / "test_imaging_extra_chunks.zarr"
+    imaging_zarr = imaging_multi_plane.save(format="zarr", folder=zarr_path, extra_chunks=(2, 2, 2))
+
+    imaging_zarr_loaded = ZarrImaging(zarr_path)
+
+    assert_imaging_equal(imaging_multi_plane, imaging_zarr)
+    assert_imaging_equal(imaging_multi_plane, imaging_zarr_loaded)
+
+    # check chunking
+    for epoch_index in range(imaging_zarr.get_num_epochs()):
+        chunk_shape = imaging_zarr._root[f"video_epoch{epoch_index}"].chunks
+        assert chunk_shape[1:] == (2, 2, 2)

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -119,11 +119,11 @@ class ZarrImagingEpoch(BaseImagingEpoch):
         """
         return self._video.shape[0]
 
-    def get_traces(
+    def get_series(
         self,
-        start_frame: int | None = None,
-        end_frame: int | None = None,
-        plane_indices: list[int | str] | None = None,
+        start_frame: int,
+        end_frame: int,
+        plane_indices: list[int] | None = None,
     ) -> np.ndarray:
         video = self._video[start_frame:end_frame]
         if plane_indices is not None:
@@ -144,8 +144,8 @@ def add_imaging_to_zarr_group(
     # save data (done the subclass)
     zarr_group.attrs["sampling_frequency"] = float(imaging.get_sampling_frequency())
     zarr_group.attrs["num_segments"] = int(imaging.get_num_segments())
-    zarr_group.create_dataset(name="shape", data=imaging.get_video_shape(), compressor=None)
-    dataset_paths = [f"videos_seg{i}" for i in range(imaging.get_num_segments())]
+    zarr_group.create_dataset(name="shape", data=imaging.shape, compressor=None)
+    dataset_paths = [f"video_seg{i}" for i in range(imaging.get_num_segments())]
 
     dtype = imaging.get_dtype() if dtype is None else dtype
     extra_chunks = zarr_kwargs.get("extra_chunks", None)

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -1,0 +1,175 @@
+from pathlib import Path
+
+import numpy as np
+import zarr
+from spikeinterface.core.chunkable_tools import write_chunkable_to_zarr
+from spikeinterface.core.core_tools import check_json
+from spikeinterface.core.job_tools import split_job_kwargs
+from spikeinterface.core.zarrextractors import (
+    add_properties_and_annotations,
+    get_default_zarr_compressor,
+    resolve_zarr_path,
+    super_zarr_open,
+)
+
+from photon_mosaic.core.baseimaging import BaseImaging, BaseImagingEpoch
+
+
+class ZarrImaging(BaseImaging):
+    """An Imaging object that is backed by a zarr array on disk.
+    This allows for memory efficient access to large imaging datasets that do not fit in memory.
+
+    Parameters
+    ----------
+    folder_path: str | Path
+        The path to the folder containing the zarr group with the imaging data.
+    storage_options: dict | None
+        Optional storage options for opening the zarr group.
+    """
+
+    def __init__(
+        self, folder_path: str | Path, storage_options: dict | None = None, load_compression_ratio: bool = False
+    ):
+        folder_path, folder_path_kwarg = resolve_zarr_path(folder_path)
+
+        self._root = super_zarr_open(folder_path, mode="r", storage_options=storage_options)
+
+        sampling_frequency = self._root.attrs.get("sampling_frequency", None)
+        num_segments = self._root.attrs.get("num_segments", None)
+        assert "shape" in self._root.keys(), "'shape' dataset not found!"
+        shapes = self._root["shape"][:]
+
+        assert sampling_frequency is not None, "'sampling_frequency' attribute not found!"
+        assert num_segments is not None, "'num_segments' attribute not found!"
+
+        BaseImaging.__init__(self, sampling_frequency=sampling_frequency, shape=shapes)
+
+        t_starts = self._root.get("t_starts", None)
+        if load_compression_ratio:
+            total_nbytes = 0
+            total_nbytes_stored = 0
+            cr_by_segment = {}
+        for segment_index in range(num_segments):
+            video_name = f"video_seg{segment_index}"
+
+            time_kwargs = {}
+            time_vector = self._root.get(f"times_seg{segment_index}", None)
+            if time_vector is not None:
+                time_kwargs["time_vector"] = time_vector
+            else:
+                if t_starts is None:
+                    t_start = None
+                else:
+                    t_start = t_starts[segment_index]
+                    if np.isnan(t_start):
+                        t_start = None
+                time_kwargs["t_start"] = t_start
+            time_kwargs["sampling_frequency"] = sampling_frequency
+
+            epoch = ZarrImagingEpoch(self._root, video_name, **time_kwargs)
+            self.add_epoch(epoch)
+
+            if load_compression_ratio:
+                nbytes_segment = self._root[video_name].nbytes
+                nbytes_stored_segment = self._root[video_name].nbytes_stored
+                if nbytes_stored_segment > 0:
+                    cr_by_segment[segment_index] = nbytes_segment / nbytes_stored_segment
+                else:
+                    cr_by_segment[segment_index] = np.nan
+
+                total_nbytes += nbytes_segment
+                total_nbytes_stored += nbytes_stored_segment
+
+        # load properties
+        if "properties" in self._root:
+            prop_group = self._root["properties"]
+            for key in prop_group.keys():
+                values = self._root["properties"][key]
+                self.set_property(key, values)
+
+        # load annotations
+        annotations = self._root.attrs.get("annotations", None)
+        if annotations is not None:
+            self.annotate(**annotations)
+        if load_compression_ratio:
+            # annotate compression ratios
+            if total_nbytes_stored > 0:
+                cr = total_nbytes / total_nbytes_stored
+            else:
+                cr = np.nan
+            self.annotate(compression_ratio=cr, compression_ratio_segments=cr_by_segment)
+
+        self._kwargs = {
+            "folder_path": folder_path_kwarg,
+            "storage_options": storage_options,
+            "load_compression_ratio": load_compression_ratio,
+        }
+
+
+class ZarrImagingEpoch(BaseImagingEpoch):
+    def __init__(self, root, dataset_name, **time_kwargs):
+        BaseImagingEpoch.__init__(self, **time_kwargs)
+        self._video = root[dataset_name]
+
+    def get_num_samples(self) -> int:
+        """Returns the number of samples in this signal block
+
+        Returns:
+            SampleIndex : Number of samples in the signal block
+        """
+        return self._video.shape[0]
+
+    def get_traces(
+        self,
+        start_frame: int | None = None,
+        end_frame: int | None = None,
+        plane_indices: list[int | str] | None = None,
+    ) -> np.ndarray:
+        video = self._video[start_frame:end_frame]
+        if plane_indices is not None:
+            video = video[..., plane_indices]
+        return video
+
+
+def add_imaging_to_zarr_group(
+    imaging: BaseImaging, zarr_group: zarr.hierarchy.Group, verbose=False, dtype=None, **kwargs
+):
+    zarr_kwargs, job_kwargs = split_job_kwargs(kwargs)
+
+    if imaging.check_if_json_serializable():
+        zarr_group.attrs["provenance"] = check_json(imaging.to_dict(recursive=True))
+    else:
+        zarr_group.attrs["provenance"] = None
+
+    # save data (done the subclass)
+    zarr_group.attrs["sampling_frequency"] = float(imaging.get_sampling_frequency())
+    zarr_group.attrs["num_segments"] = int(imaging.get_num_segments())
+    zarr_group.create_dataset(name="shape", data=imaging.get_video_shape(), compressor=None)
+    dataset_paths = [f"videos_seg{i}" for i in range(imaging.get_num_segments())]
+
+    dtype = imaging.get_dtype() if dtype is None else dtype
+    extra_chunks = zarr_kwargs.get("extra_chunks", None)
+    global_compressor = zarr_kwargs.pop("compressor", get_default_zarr_compressor())
+    compressor_by_dataset = zarr_kwargs.pop("compressor_by_dataset", {})
+    global_filters = zarr_kwargs.pop("filters", None)
+    filters_by_dataset = zarr_kwargs.pop("filters_by_dataset", {})
+    compressor_videos = compressor_by_dataset.get("videos", global_compressor)
+    filters_videos = filters_by_dataset.get("videos", global_filters)
+    compressor_times = compressor_by_dataset.get("times", global_compressor)
+    filters_times = filters_by_dataset.get("times", global_filters)
+
+    write_chunkable_to_zarr(
+        chunkable=imaging,
+        zarr_group=zarr_group,
+        dataset_paths=dataset_paths,
+        compressor_data=compressor_videos,
+        filters_data=filters_videos,
+        compressor_times=compressor_times,
+        filters_times=filters_times,
+        dtype=dtype,
+        extra_chunks=extra_chunks,
+        verbose=verbose,
+        **job_kwargs,
+    )
+
+    add_properties_and_annotations(zarr_group, imaging)

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -173,4 +173,4 @@ def add_imaging_to_zarr_group(
     )
 
     add_properties_and_annotations(zarr_group, imaging)
-    zarr_group.attrs["provenance"] = retrieve_importing_provenance(ZarrImaging)
+    zarr_group.attrs["zarr_class_info   "] = retrieve_importing_provenance(ZarrImaging)

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 import zarr
 from spikeinterface.core.chunkable_tools import write_chunkable_to_zarr
-from spikeinterface.core.core_tools import check_json
+from spikeinterface.core.core_tools import check_json, retrieve_importing_provenance
 from spikeinterface.core.job_tools import split_job_kwargs
 from spikeinterface.core.zarrextractors import (
     add_properties_and_annotations,
@@ -173,3 +173,4 @@ def add_imaging_to_zarr_group(
     )
 
     add_properties_and_annotations(zarr_group, imaging)
+    zarr_group.attrs["provenance"] = retrieve_importing_provenance(ZarrImaging)

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -128,7 +128,7 @@ class ZarrImagingEpoch(BaseImagingEpoch):
         video = self._video[start_frame:end_frame]
         if plane_indices is not None:
             video = video[..., plane_indices]
-        return video
+        return np.asarray(video)
 
 
 def add_imaging_to_zarr_group(

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -62,7 +62,7 @@ class ZarrImaging(BaseImaging):
                 else:
                     t_start = t_starts[segment_index]
                     if np.isnan(t_start):
-                        t_start = None
+                        t_start = None  # pragma: no cover
                 time_kwargs["t_start"] = t_start
             time_kwargs["sampling_frequency"] = sampling_frequency
 
@@ -75,7 +75,7 @@ class ZarrImaging(BaseImaging):
                 if nbytes_stored_segment > 0:
                     cr_by_segment[segment_index] = nbytes_segment / nbytes_stored_segment
                 else:
-                    cr_by_segment[segment_index] = np.nan
+                    cr_by_segment[segment_index] = np.nan  # pragma: no cover
 
                 total_nbytes += nbytes_segment
                 total_nbytes_stored += nbytes_stored_segment
@@ -96,7 +96,7 @@ class ZarrImaging(BaseImaging):
             if total_nbytes_stored > 0:
                 cr = total_nbytes / total_nbytes_stored
             else:
-                cr = np.nan
+                cr = np.nan  # pragma: no cover
             self.annotate(compression_ratio=cr, compression_ratio_segments=cr_by_segment)
 
         self._kwargs = {
@@ -139,7 +139,7 @@ def add_imaging_to_zarr_group(
     if imaging.check_if_json_serializable():
         zarr_group.attrs["provenance"] = check_json(imaging.to_dict(recursive=True))
     else:
-        zarr_group.attrs["provenance"] = None
+        zarr_group.attrs["provenance"] = None  # pragma: no cover
 
     # save data (done the subclass)
     zarr_group.attrs["sampling_frequency"] = float(imaging.get_sampling_frequency())
@@ -173,4 +173,4 @@ def add_imaging_to_zarr_group(
     )
 
     add_properties_and_annotations(zarr_group, imaging)
-    zarr_group.attrs["zarr_class_info   "] = retrieve_importing_provenance(ZarrImaging)
+    zarr_group.attrs["zarr_class_info"] = retrieve_importing_provenance(ZarrImaging)

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -32,15 +32,17 @@ class ZarrImaging(BaseImaging):
     ):
         folder_path, folder_path_kwarg = resolve_zarr_path(folder_path)
 
+        # super_zarr_open is a helper function that deals with consolidated/non-consolidated stores
+        # and anonymous/non-anonymous cloud access
         self._root = super_zarr_open(folder_path, mode="r", storage_options=storage_options)
 
         sampling_frequency = self._root.attrs.get("sampling_frequency", None)
-        num_segments = self._root.attrs.get("num_segments", None)
+        num_epochs = self._root.attrs.get("num_epochs", None)
         assert "shape" in self._root.keys(), "'shape' dataset not found!"
         shapes = self._root["shape"][:]
 
         assert sampling_frequency is not None, "'sampling_frequency' attribute not found!"
-        assert num_segments is not None, "'num_segments' attribute not found!"
+        assert num_epochs is not None, "'num_epochs' attribute not found!"
 
         BaseImaging.__init__(self, sampling_frequency=sampling_frequency, shape=shapes)
 
@@ -48,19 +50,19 @@ class ZarrImaging(BaseImaging):
         if load_compression_ratio:
             total_nbytes = 0
             total_nbytes_stored = 0
-            cr_by_segment = {}
-        for segment_index in range(num_segments):
-            video_name = f"video_seg{segment_index}"
+            cr_by_epoch = {}
+        for epoch_index in range(num_epochs):
+            video_name = f"video_epoch{epoch_index}"
 
             time_kwargs = {}
-            time_vector = self._root.get(f"times_seg{segment_index}", None)
+            time_vector = self._root.get(f"times_epoch{epoch_index}", None)
             if time_vector is not None:
                 time_kwargs["time_vector"] = time_vector
             else:
                 if t_starts is None:
                     t_start = None
                 else:
-                    t_start = t_starts[segment_index]
+                    t_start = t_starts[epoch_index]
                     if np.isnan(t_start):
                         t_start = None  # pragma: no cover
                 time_kwargs["t_start"] = t_start
@@ -70,15 +72,15 @@ class ZarrImaging(BaseImaging):
             self.add_epoch(epoch)
 
             if load_compression_ratio:
-                nbytes_segment = self._root[video_name].nbytes
-                nbytes_stored_segment = self._root[video_name].nbytes_stored
-                if nbytes_stored_segment > 0:
-                    cr_by_segment[segment_index] = nbytes_segment / nbytes_stored_segment
+                nbytes_epoch = self._root[video_name].nbytes
+                nbytes_stored_epoch = self._root[video_name].nbytes_stored
+                if nbytes_stored_epoch > 0:
+                    cr_by_epoch[epoch_index] = nbytes_epoch / nbytes_stored_epoch
                 else:
-                    cr_by_segment[segment_index] = np.nan  # pragma: no cover
+                    cr_by_epoch[epoch_index] = np.nan  # pragma: no cover
 
-                total_nbytes += nbytes_segment
-                total_nbytes_stored += nbytes_stored_segment
+                total_nbytes += nbytes_epoch
+                total_nbytes_stored += nbytes_stored_epoch
 
         # load properties
         if "properties" in self._root:
@@ -97,7 +99,7 @@ class ZarrImaging(BaseImaging):
                 cr = total_nbytes / total_nbytes_stored
             else:
                 cr = np.nan  # pragma: no cover
-            self.annotate(compression_ratio=cr, compression_ratio_segments=cr_by_segment)
+            self.annotate(compression_ratio=cr, compression_ratio_epochs=cr_by_epoch)
 
         self._kwargs = {
             "folder_path": folder_path_kwarg,
@@ -134,6 +136,25 @@ class ZarrImagingEpoch(BaseImagingEpoch):
 def add_imaging_to_zarr_group(
     imaging: BaseImaging, zarr_group: zarr.hierarchy.Group, verbose=False, dtype=None, **kwargs
 ):
+    """Adds an Imaging object to a zarr group.
+
+    Parameters
+    ----------
+    imaging: BaseImaging
+        The Imaging object to add to the zarr group.
+    zarr_group: zarr.hierarchy.Group
+        The zarr group to which the imaging data should be added.
+    verbose: bool
+        Whether to print verbose output during the writing process.
+    dtype: np.dtype | None
+        The dtype to use for the video datasets. If None, the dtype of the imaging data
+        will be used.
+    **kwargs:
+        Additional keyword arguments to pass to the write_chunkable_to_zarr function. This can include
+        zarr-specific arguments (e.g., compressor, filters) as well as job-related arguments
+        (e.g., n_jobs).
+    """
+
     zarr_kwargs, job_kwargs = split_job_kwargs(kwargs)
 
     if imaging.check_if_json_serializable():
@@ -143,9 +164,17 @@ def add_imaging_to_zarr_group(
 
     # save data (done the subclass)
     zarr_group.attrs["sampling_frequency"] = float(imaging.get_sampling_frequency())
-    zarr_group.attrs["num_segments"] = int(imaging.get_num_segments())
+    zarr_group.attrs["num_epochs"] = int(imaging.get_num_epochs())
     zarr_group.create_dataset(name="shape", data=imaging.shape, compressor=None)
-    dataset_paths = [f"video_seg{i}" for i in range(imaging.get_num_segments())]
+    dataset_paths = [f"video_epoch{i}" for i in range(imaging.get_num_epochs())]
+    dataset_timestamps_paths: list | None = None
+    if any(imaging.has_time_vector(i) for i in range(imaging.get_num_epochs())):
+        dataset_timestamps_paths = []
+        for i in range(imaging.get_num_epochs()):
+            if imaging.has_time_vector(i):
+                dataset_timestamps_paths.append(f"times_epoch{i}")
+            else:
+                dataset_timestamps_paths.append(None)
 
     dtype = imaging.get_dtype() if dtype is None else dtype
     extra_chunks = zarr_kwargs.get("extra_chunks", None)
@@ -162,6 +191,7 @@ def add_imaging_to_zarr_group(
         chunkable=imaging,
         zarr_group=zarr_group,
         dataset_paths=dataset_paths,
+        dataset_timestamps_paths=dataset_timestamps_paths,
         compressor_data=compressor_videos,
         filters_data=filters_videos,
         compressor_times=compressor_times,


### PR DESCRIPTION
Fixes #32 

TODO:
- [x] tests