### PR TITLE
implement basic splitting

### DIFF
--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -3,4 +3,4 @@ from .baserois import BaseRois
 from .numpyimaging import NumpyImaging
 from .generators import generate_random_imaging, generate_rois
 from .binaryimaging import read_binary
-from .split import SelectEpochImaging, split_epochs 
+from .split import SelectEpochImaging, split_epochs

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -3,3 +3,4 @@ from .baserois import BaseRois
 from .numpyimaging import NumpyImaging
 from .generators import generate_random_imaging, generate_rois
 from .binaryimaging import read_binary
+from .split import SelectEpochImaging, split_epochs 

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -14,7 +14,8 @@ def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) ->
         raise ValueError("epoch_indices must contain at least one index")
 
     for epoch_index in normalized_epoch_indices:
-        if not isinstance(epoch_index, int):
+        # isinstance(True, int) returns True, so we need the second check here
+        if not isinstance(epoch_index, int) or isinstance(epoch_index, bool): 
             raise TypeError("All epoch indices must be ints")
         if not 0 <= epoch_index < num_epochs:
             raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -15,7 +15,7 @@ def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) ->
 
     for epoch_index in normalized_epoch_indices:
         # isinstance(True, int) returns True, so we need the second check here
-        if not isinstance(epoch_index, int) or isinstance(epoch_index, bool): 
+        if not isinstance(epoch_index, int) or isinstance(epoch_index, bool):
             raise TypeError("All epoch indices must be ints")
         if not 0 <= epoch_index < num_epochs:
             raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -2,47 +2,46 @@ from .baseimaging import BaseImaging
 
 
 def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) -> list[int]:
-	"""Normalize and validate epoch indices requested by the user."""
-	if type(epoch_indices) is int:
-		normalized_epoch_indices = [epoch_indices]
-	elif isinstance(epoch_indices, list):
-		normalized_epoch_indices = epoch_indices
-	else:
-		raise TypeError("epoch_indices must be an int or a list of ints")
+    """Normalize and validate epoch indices requested by the user."""
+    if isinstance(epoch_indices,int):
+        normalized_epoch_indices = [epoch_indices]
+    elif isinstance(epoch_indices, list):
+        normalized_epoch_indices = epoch_indices
+    else:
+        raise TypeError("epoch_indices must be an int or a list of ints")
 
-	if len(normalized_epoch_indices) == 0:
-		raise ValueError("epoch_indices must contain at least one index")
+    if len(normalized_epoch_indices) == 0:
+        raise ValueError("epoch_indices must contain at least one index")
 
-	for epoch_index in normalized_epoch_indices:
-		if type(epoch_index) is not int:
-			raise TypeError("All epoch indices must be ints")
-		if not 0 <= epoch_index < num_epochs:
-			raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")
+    for epoch_index in normalized_epoch_indices:
+        if not isinstance(epoch_index, int):
+            raise TypeError("All epoch indices must be ints")
+        if not 0 <= epoch_index < num_epochs:
+            raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")
 
-	return normalized_epoch_indices
+    return normalized_epoch_indices
 
 
 class SelectEpochImaging(BaseImaging):
-	"""Proxy imaging object exposing only selected epochs from a parent imaging."""
+    """Proxy imaging object exposing only selected epochs from a parent imaging."""
 
-	def __init__(self, imaging: BaseImaging, epoch_indices: int | list[int]):
-		normalized_epoch_indices = _normalize_epoch_indices(epoch_indices, imaging.get_num_epochs())
+    def __init__(self, imaging: BaseImaging, epoch_indices: int | list[int]):
+        normalized_epoch_indices = _normalize_epoch_indices(epoch_indices, imaging.get_num_epochs())
 
-		BaseImaging.__init__(self, sampling_frequency=imaging.sampling_frequency, shape=imaging.shape)
-		imaging.copy_metadata(self)
+        BaseImaging.__init__(self, sampling_frequency=imaging.sampling_frequency, shape=imaging.shape)
+        imaging.copy_metadata(self)
 
-		for epoch_index in normalized_epoch_indices:
-			imaging_epoch = imaging.epochs[epoch_index]
-			self.add_epoch(imaging_epoch)
+        for epoch_index in normalized_epoch_indices:
+            imaging_epoch = imaging.epochs[epoch_index]
+            self.add_epoch(imaging_epoch)
 
-		self._parent = imaging
-		self._kwargs = {
-			"imaging": imaging,
-			"epoch_indices": normalized_epoch_indices,
-		}
+        self._parent = imaging
+        self._kwargs = {
+            "imaging": imaging,
+            "epoch_indices": normalized_epoch_indices,
+        }
 
 
 def split_epochs(imaging: BaseImaging, epoch_indices: int | list[int]) -> SelectEpochImaging:
-	"""Return a proxy imaging object with only the requested epochs."""
-	return SelectEpochImaging(imaging=imaging, epoch_indices=epoch_indices)
-
+    """Return a proxy imaging object with only the requested epochs."""
+    return SelectEpochImaging(imaging=imaging, epoch_indices=epoch_indices)

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -3,7 +3,7 @@ from .baseimaging import BaseImaging
 
 def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) -> list[int]:
     """Normalize and validate epoch indices requested by the user."""
-    if isinstance(epoch_indices,int):
+    if isinstance(epoch_indices, int):
         normalized_epoch_indices = [epoch_indices]
     elif isinstance(epoch_indices, list):
         normalized_epoch_indices = epoch_indices

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -1,0 +1,48 @@
+from .baseimaging import BaseImaging
+
+
+def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) -> list[int]:
+	"""Normalize and validate epoch indices requested by the user."""
+	if type(epoch_indices) is int:
+		normalized_epoch_indices = [epoch_indices]
+	elif isinstance(epoch_indices, list):
+		normalized_epoch_indices = epoch_indices
+	else:
+		raise TypeError("epoch_indices must be an int or a list of ints")
+
+	if len(normalized_epoch_indices) == 0:
+		raise ValueError("epoch_indices must contain at least one index")
+
+	for epoch_index in normalized_epoch_indices:
+		if type(epoch_index) is not int:
+			raise TypeError("All epoch indices must be ints")
+		if not 0 <= epoch_index < num_epochs:
+			raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")
+
+	return normalized_epoch_indices
+
+
+class SelectEpochImaging(BaseImaging):
+	"""Proxy imaging object exposing only selected epochs from a parent imaging."""
+
+	def __init__(self, imaging: BaseImaging, epoch_indices: int | list[int]):
+		normalized_epoch_indices = _normalize_epoch_indices(epoch_indices, imaging.get_num_epochs())
+
+		BaseImaging.__init__(self, sampling_frequency=imaging.sampling_frequency, shape=imaging.shape)
+		imaging.copy_metadata(self)
+
+		for epoch_index in normalized_epoch_indices:
+			imaging_epoch = imaging.epochs[epoch_index]
+			self.add_epoch(imaging_epoch)
+
+		self._parent = imaging
+		self._kwargs = {
+			"imaging": imaging,
+			"epoch_indices": normalized_epoch_indices,
+		}
+
+
+def split_epochs(imaging: BaseImaging, epoch_indices: int | list[int]) -> SelectEpochImaging:
+	"""Return a proxy imaging object with only the requested epochs."""
+	return SelectEpochImaging(imaging=imaging, epoch_indices=epoch_indices)
+

--- a/src/photon_mosaic/core/tests/test_split.py
+++ b/src/photon_mosaic/core/tests/test_split.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from photon_mosaic.core.generators import generate_random_imaging
+from photon_mosaic.core.split import SelectEpochImaging, split_epochs
+
+
+def test_split_epoch_with_single_index_returns_single_epoch_proxy():
+    imaging = generate_random_imaging(num_frames=(4, 6, 8), height=5, width=7, sampling_frequency=20.0, seed=0)
+
+    split_imaging = split_epochs(imaging, 1)
+
+    assert isinstance(split_imaging, SelectEpochImaging)
+    assert split_imaging.get_num_epochs() == 1
+    np.testing.assert_allclose(split_imaging.get_series(), imaging.get_series(epoch_index=1))
+    assert split_imaging.epochs[0] is imaging.epochs[1]
+
+
+def test_split_epoch_with_multiple_indices_preserves_order():
+    imaging = generate_random_imaging(num_frames=(3, 5, 7), height=4, width=6, sampling_frequency=15.0, seed=1)
+
+    split_imaging = split_epochs(imaging, [2, 0])
+
+    assert split_imaging.get_num_epochs() == 2
+    np.testing.assert_allclose(split_imaging.get_series(epoch_index=0), imaging.get_series(epoch_index=2))
+    np.testing.assert_allclose(split_imaging.get_series(epoch_index=1), imaging.get_series(epoch_index=0))
+    assert split_imaging.epochs[0] is imaging.epochs[2]
+    assert split_imaging.epochs[1] is imaging.epochs[0]
+
+
+def test_split_epoch_raises_on_invalid_indices():
+    imaging = generate_random_imaging(num_frames=(3, 5), height=4, width=6, sampling_frequency=15.0, seed=2)
+
+    with pytest.raises(IndexError):
+        _ = split_epochs(imaging, 2)
+
+    with pytest.raises(ValueError):
+        _ = split_epochs(imaging, [])
+
+    with pytest.raises(TypeError):
+        _ = split_epochs(imaging, [0, 1.5])
+
+    with pytest.raises(TypeError):
+        _ = split_epochs(imaging, True)
+
+    with pytest.raises(TypeError):
+        _ = split_epochs(imaging, [0, False])


### PR DESCRIPTION
Closes #45 

Adds a [utility function `split_epochs`](https://github.com/photon-mosaic/photon-mosaic/issues/46#issuecomment-4073940063) to split out Epochs defined by `epoch_indices` via a proxy Imaging class.

I also considered an alternative implementation strategy where `split_epochs` would create a new Imaging object of the same type as the input Imaging object but that proved hard. The current implementation is also more in keeping with our idea of lazy evaluation via chaining objects together, and only `get_series` actually being final (and this is ~what `spikeinterface` does according to my AI assistant (?))

Question for reviewers: should the proxy class `SelectEpochImaging` be moved to `baseimaging.py` (analogous to `SelectROIs` class being in `baserois.py`)?