### PR TITLE
Update `chunkable` to `time_series` and install from SI main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
-    "spikeinterface @ git+https://github.com/alejoe91/spikeinterface.git@793aab6ab9daa1becd9c5347f34afcae67275a8c",
+    "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@409d1f548f1c56829731f93dc61b1bed71f43006",
     "roiextractors"
 ]
 

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -3,16 +3,16 @@ from math import prod
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
 from spikeinterface.core.base import BaseExtractor
-from spikeinterface.core.chunkable import ChunkableMixin, ChunkableSegment
-from spikeinterface.core.chunkable_tools import get_chunks, write_binary
 from spikeinterface.core.core_tools import convert_bytes_to_str, convert_seconds_to_str
+from spikeinterface.core.time_series import TimeSeries, TimeSeriesSegment
+from spikeinterface.core.time_series_tools import get_chunks, write_binary
 
 
-class BaseImaging(BaseExtractor, ChunkableMixin):
+class BaseImaging(BaseExtractor, TimeSeries):
     """
     Base class for imaging extractors.
 
-    The class inherits from `BaseExtractor` and `ChunkableMixin` to provide common functionality
+    The class inherits from `BaseExtractor` and `TimeSeries` to provide common functionality
     for imaging data handling.
 
     Each `BaseImaging` instance is associated to a single "channel".
@@ -473,7 +473,7 @@ class BaseImaging(BaseExtractor, ChunkableMixin):
         return cached
 
 
-class BaseImagingEpoch(ChunkableSegment):
+class BaseImagingEpoch(TimeSeriesSegment):
     """
     Abstract class representing a video epoch.
     """

--- a/src/photon_mosaic/core/zarrimaging.py
+++ b/src/photon_mosaic/core/zarrimaging.py
@@ -2,9 +2,9 @@ from pathlib import Path
 
 import numpy as np
 import zarr
-from spikeinterface.core.chunkable_tools import write_chunkable_to_zarr
 from spikeinterface.core.core_tools import check_json, retrieve_importing_provenance
 from spikeinterface.core.job_tools import split_job_kwargs
+from spikeinterface.core.time_series_tools import _write_time_series_to_zarr
 from spikeinterface.core.zarrextractors import (
     add_properties_and_annotations,
     get_default_zarr_compressor,
@@ -150,7 +150,7 @@ def add_imaging_to_zarr_group(
         The dtype to use for the video datasets. If None, the dtype of the imaging data
         will be used.
     **kwargs:
-        Additional keyword arguments to pass to the write_chunkable_to_zarr function. This can include
+        Additional keyword arguments to pass to the _write_time_series_to_zarr function. This can include
         zarr-specific arguments (e.g., compressor, filters) as well as job-related arguments
         (e.g., n_jobs).
     """
@@ -187,8 +187,8 @@ def add_imaging_to_zarr_group(
     compressor_times = compressor_by_dataset.get("times", global_compressor)
     filters_times = filters_by_dataset.get("times", global_filters)
 
-    write_chunkable_to_zarr(
-        chunkable=imaging,
+    _write_time_series_to_zarr(
+        time_series=imaging,
         zarr_group=zarr_group,
         dataset_paths=dataset_paths,
         dataset_timestamps_paths=dataset_timestamps_paths,


### PR DESCRIPTION
In SpikeInterface https://github.com/SpikeInterface/spikeinterface/pull/4533 we renamed `Chunkable` to `TimeSeries`.

This PR updates the photon-mosaic implementation and installs SpikeInterface from main!