### PR TITLE
include further dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
     "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@409d1f548f1c56829731f93dc61b1bed71f43006",
-    "roiextractors",
+    "roiextractors[full]",
     "pydantic>=2",
     "pydantic-settings>=2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
     "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@409d1f548f1c56829731f93dc61b1bed71f43006",
-    "roiextractors",
-    "tifffile",
-    "scanimage-tiff-reader",
-    "natsort",
+    "roiextractors>=0.8.0",
+    "tifffile>=2018.11.6",
+    "scanimage-tiff-reader>=1.4.1.4",
+    "natsort>=8.3.1",
     "pydantic>=2",
     "pydantic-settings>=2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
     "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@409d1f548f1c56829731f93dc61b1bed71f43006",
-    "roiextractors[full]",
+    "roiextractors",
+    "tifffile",
+    "scanimage-tiff-reader",
+    "natsort",
     "pydantic>=2",
     "pydantic-settings>=2",
 ]


### PR DESCRIPTION
Closes #67.

Includes specific dependencies in `pyproject.toml`, as per discussion. 