### PR TITLE
fix: install full roiextractors dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,7 @@ requires-python = ">=3.10.0"
 dynamic = ["version"]
 dependencies = [
     "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git@409d1f548f1c56829731f93dc61b1bed71f43006",
-    "roiextractors>=0.8.0",
-    "tifffile>=2018.11.6",
-    "scanimage-tiff-reader>=1.4.1.4",
-    "natsort>=8.3.1",
-    "pydantic>=2",
+    "roiextractors[full]>=0.8.0",
     "pydantic-settings>=2",
 ]
 


### PR DESCRIPTION
- `pyproject.toml` contains the full install of `roiextractors`
- kept ceiling bound
- resolves #67 