### PR TITLE
fix: clamp contrast sample to frame count 

### DIFF
--- a/src/photon_mosaic/preprocessing/suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/suite2p_registration.py
@@ -507,6 +507,18 @@ class RegisterSuite2PImagingEpoch(BasePreprocessorEpoch):
         import torch
         from suite2p.registration import register
 
+        num_samples = self.parent_imaging_epoch.get_num_samples()
+        if end_frame > num_samples:
+            logging.warning(
+                "end_frame %d exceeds recording length %d; clamping. "
+                "This usually indicates a miscalculation upstream.",
+                end_frame,
+                num_samples,
+            )
+            end_frame = num_samples
+        if start_frame > end_frame:
+            start_frame = end_frame
+
         video = self.parent_imaging_epoch.get_series(start_frame, end_frame)
         num_planes = video.shape[3] if video.ndim == 4 else 1
 
@@ -520,9 +532,7 @@ class RegisterSuite2PImagingEpoch(BasePreprocessorEpoch):
             planes_to_process = list(plane_indices)
 
         disps = self.motion.displacements[self.epoch_index]
-        # Match parent epoch truncation when end_frame is past the recording.
-        n_frames = video.shape[0]
-        end_frame = start_frame + n_frames
+        n_frames = end_frame - start_frame
         H, W = video.shape[1], video.shape[2]
         output = np.empty((n_frames, H, W, len(planes_to_process)), dtype=np.float32)
         if n_frames == 0:

--- a/src/photon_mosaic/preprocessing/suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/suite2p_registration.py
@@ -520,9 +520,16 @@ class RegisterSuite2PImagingEpoch(BasePreprocessorEpoch):
             planes_to_process = list(plane_indices)
 
         disps = self.motion.displacements[self.epoch_index]
-        n_frames = end_frame - start_frame
+        # Use the actual frame count returned by the parent epoch — when
+        # end_frame exceeds the available samples, NumpyImagingEpoch and
+        # friends silently truncate, so we must match that. The empty-range
+        # case occurs when spikeinterface chunking asks past the end.
+        n_frames = video.shape[0]
+        end_frame = start_frame + n_frames
         H, W = video.shape[1], video.shape[2]
         output = np.empty((n_frames, H, W, len(planes_to_process)), dtype=np.float32)
+        if n_frames == 0:
+            return output
 
         for i, p in enumerate(planes_to_process):
             plane_video = video[:, :, :, p] if video.ndim == 4 else video

--- a/src/photon_mosaic/preprocessing/suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/suite2p_registration.py
@@ -517,7 +517,9 @@ class RegisterSuite2PImagingEpoch(BasePreprocessorEpoch):
             )
             end_frame = num_samples
         if start_frame > end_frame:
-            start_frame = end_frame
+            raise ValueError(
+                f"start_frame ({start_frame}) is past end_frame ({end_frame}); " f"recording length is {num_samples}."
+            )
 
         video = self.parent_imaging_epoch.get_series(start_frame, end_frame)
         num_planes = video.shape[3] if video.ndim == 4 else 1

--- a/src/photon_mosaic/preprocessing/suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/suite2p_registration.py
@@ -520,10 +520,7 @@ class RegisterSuite2PImagingEpoch(BasePreprocessorEpoch):
             planes_to_process = list(plane_indices)
 
         disps = self.motion.displacements[self.epoch_index]
-        # Use the actual frame count returned by the parent epoch — when
-        # end_frame exceeds the available samples, NumpyImagingEpoch and
-        # friends silently truncate, so we must match that. The empty-range
-        # case occurs when spikeinterface chunking asks past the end.
+        # Match parent epoch truncation when end_frame is past the recording.
         n_frames = video.shape[0]
         end_frame = start_frame + n_frames
         H, W = video.shape[1], video.shape[2]

--- a/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
@@ -290,31 +290,29 @@ class TestRegisterSuite2PImagingEpoch:
         np.testing.assert_allclose(result[..., 0], result[0:1, ..., 0].repeat(5, axis=0), atol=1e-3)
         np.testing.assert_allclose(result[..., 1], result[0:1, ..., 1].repeat(5, axis=0), atol=1e-3)
 
-    def test_get_series_end_frame_past_end_truncates(self, imaging, motion):
-        # Parent NumpyImagingEpoch silently truncates when end_frame > num_samples
-        # (it slices the underlying ndarray). The registration wrapper must match
-        # that contract — historically it pre-allocated a buffer of end-start frames
-        # and crashed broadcasting the shorter shifted result into it.
+    def test_get_series_end_frame_past_end_warns_and_clamps(self, imaging, motion, caplog):
+        # Over-requested range is clamped to the recording length, with a warning.
         parent_epoch = imaging.epochs[0]
         epoch = RegisterSuite2PImagingEpoch(parent_epoch, motion, 0)
         n = epoch.get_num_samples()
 
-        result = epoch.get_series(0, n + 50)
+        with caplog.at_level("WARNING"):
+            result = epoch.get_series(0, n + 50)
 
         assert result.shape == (n, 12, 12, 1)
+        assert any("exceeds recording length" in rec.message for rec in caplog.records)
 
-    def test_get_series_empty_range_past_end(self, imaging, motion):
-        # spikeinterface chunking can ask for a range entirely past the recording end
-        # (e.g. when chunk_size doesn't evenly divide num_samples). The wrapper must
-        # return an empty array instead of calling Suite2P's shift_frames with an
-        # empty tensor list, which raises "stack expects a non-empty TensorList".
+    def test_get_series_empty_range_past_end(self, imaging, motion, caplog):
+        # Range entirely past the end clamps to empty without invoking suite2p.
         parent_epoch = imaging.epochs[0]
         epoch = RegisterSuite2PImagingEpoch(parent_epoch, motion, 0)
         n = epoch.get_num_samples()
 
-        result = epoch.get_series(n + 10, n + 20)
+        with caplog.at_level("WARNING"):
+            result = epoch.get_series(n + 10, n + 20)
 
         assert result.shape == (0, 12, 12, 1)
+        assert any("exceeds recording length" in rec.message for rec in caplog.records)
 
 
 def test_register_suite2p_is_alias():

--- a/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
@@ -290,6 +290,32 @@ class TestRegisterSuite2PImagingEpoch:
         np.testing.assert_allclose(result[..., 0], result[0:1, ..., 0].repeat(5, axis=0), atol=1e-3)
         np.testing.assert_allclose(result[..., 1], result[0:1, ..., 1].repeat(5, axis=0), atol=1e-3)
 
+    def test_get_series_end_frame_past_end_truncates(self, imaging, motion):
+        # Parent NumpyImagingEpoch silently truncates when end_frame > num_samples
+        # (it slices the underlying ndarray). The registration wrapper must match
+        # that contract — historically it pre-allocated a buffer of end-start frames
+        # and crashed broadcasting the shorter shifted result into it.
+        parent_epoch = imaging.epochs[0]
+        epoch = RegisterSuite2PImagingEpoch(parent_epoch, motion, 0)
+        n = epoch.get_num_samples()
+
+        result = epoch.get_series(0, n + 50)
+
+        assert result.shape == (n, 12, 12, 1)
+
+    def test_get_series_empty_range_past_end(self, imaging, motion):
+        # spikeinterface chunking can ask for a range entirely past the recording end
+        # (e.g. when chunk_size doesn't evenly divide num_samples). The wrapper must
+        # return an empty array instead of calling Suite2P's shift_frames with an
+        # empty tensor list, which raises "stack expects a non-empty TensorList".
+        parent_epoch = imaging.epochs[0]
+        epoch = RegisterSuite2PImagingEpoch(parent_epoch, motion, 0)
+        n = epoch.get_num_samples()
+
+        result = epoch.get_series(n + 10, n + 20)
+
+        assert result.shape == (0, 12, 12, 1)
+
 
 def test_register_suite2p_is_alias():
     assert register_suite2p is RegisterSuite2PImaging

--- a/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
@@ -302,17 +302,14 @@ class TestRegisterSuite2PImagingEpoch:
         assert result.shape == (n, 12, 12, 1)
         assert any("exceeds recording length" in rec.message for rec in caplog.records)
 
-    def test_get_series_empty_range_past_end(self, imaging, motion, caplog):
-        # Range entirely past the end clamps to empty without invoking suite2p.
+    def test_get_series_start_past_end_raises(self, imaging, motion):
+        # start_frame past the recording is a caller bug; raise instead of papering over.
         parent_epoch = imaging.epochs[0]
         epoch = RegisterSuite2PImagingEpoch(parent_epoch, motion, 0)
         n = epoch.get_num_samples()
 
-        with caplog.at_level("WARNING"):
-            result = epoch.get_series(n + 10, n + 20)
-
-        assert result.shape == (0, 12, 12, 1)
-        assert any("exceeds recording length" in rec.message for rec in caplog.records)
+        with pytest.raises(ValueError, match="past end_frame"):
+            epoch.get_series(n + 10, n + 20)
 
 
 def test_register_suite2p_is_alias():

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -117,10 +117,7 @@ class ImagingSeriesWidget(BaseWidget):
         self.play_thread = None
         self.playback_fps = min(10.0, dp.frame_rate)  # Default playback speed
 
-        # Calculate global contrast range from multiple frames for consistent colorbar
-        # Sample frames throughout the video to get representative range. Clamp to
-        # dp.num_frames so we don't over-request from extractors that don't
-        # silently truncate past the end of the recording.
+        # Sample up to 100 frames to compute a global vmin/vmax for the colormap.
         num_samples = min(100, dp.num_frames)
 
         # Store global vmin/vmax for each view

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -118,8 +118,10 @@ class ImagingSeriesWidget(BaseWidget):
         self.playback_fps = min(10.0, dp.frame_rate)  # Default playback speed
 
         # Calculate global contrast range from multiple frames for consistent colorbar
-        # Sample frames throughout the video to get representative range
-        num_samples = 100
+        # Sample frames throughout the video to get representative range. Clamp to
+        # dp.num_frames so we don't over-request from extractors that don't
+        # silently truncate past the end of the recording.
+        num_samples = min(100, dp.num_frames)
 
         # Store global vmin/vmax for each view
         self.global_vmin = {}

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -152,3 +152,28 @@ class TestImagingSeriesWidgetInit:
     def test_frame_rate_from_imaging(self, small_imaging):
         w = self._make_widget(small_imaging)
         assert w.data_plot["frame_rate"] == small_imaging.sampling_frequency
+
+    def test_plot_ipywidgets_clamps_contrast_sample_to_num_frames(self):
+        # Regression: the contrast-sampling step used a hardcoded num_samples=100
+        # call to imaging.get_series(0, 100). NumpyImaging silently truncates, but
+        # strict extractors (e.g. ScanImageImagingExtractor) raise IndexError when
+        # end > num_samples. The widget must clamp the request to dp.num_frames.
+        tiny = generate_random_imaging(num_frames=10, height=16, width=16, seed=0)
+        captured = []
+        sentinel = RuntimeError("stop after recording")
+
+        def recording_get_series(*args, **kwargs):
+            end_frame = args[1] if len(args) >= 2 else kwargs.get("end_frame")
+            captured.append(end_frame)
+            raise sentinel  # short-circuit before matplotlib/ipywidgets setup
+
+        tiny.get_series = recording_get_series
+
+        with (
+            patch.object(ImagingSeriesWidget, "check_backend", return_value="ipywidgets"),
+            patch("spikeinterface.widgets.utils_ipywidgets.check_ipywidget_backend"),
+        ):
+            with pytest.raises(RuntimeError, match="stop after recording"):
+                ImagingSeriesWidget(tiny, immediate_plot=True)
+
+        assert captured == [10], f"expected widget to clamp end_frame to num_frames=10; calls were {captured}"

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -154,10 +154,7 @@ class TestImagingSeriesWidgetInit:
         assert w.data_plot["frame_rate"] == small_imaging.sampling_frequency
 
     def test_plot_ipywidgets_clamps_contrast_sample_to_num_frames(self):
-        # Regression: the contrast-sampling step used a hardcoded num_samples=100
-        # call to imaging.get_series(0, 100). NumpyImaging silently truncates, but
-        # strict extractors (e.g. ScanImageImagingExtractor) raise IndexError when
-        # end > num_samples. The widget must clamp the request to dp.num_frames.
+        # Contrast sampling must request at most num_frames, not a hardcoded 100.
         tiny = generate_random_imaging(num_frames=10, height=16, width=16, seed=0)
         captured = []
         sentinel = RuntimeError("stop after recording")


### PR DESCRIPTION
Bug found while playing with the file mentioned in #10, which happens to have not that many frames. 

The widget hardcoded num_samples=100 when calling imaging.get_series(0, 100)
to compute vmin/vmax percentiles. `NumpyImaging` silently truncates on
over-request, but strict extractors (e.g. ScanImageImagingExtractor) raise
IndexError. Clamp to `dp.num_frames`.

Co-Authored-By: Claude Opus 4.7