### PR TITLE
Multi-field (mesoscope) imaging + ROI analysis [WIP/draft]

### DIFF
--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -3,15 +3,14 @@ from .baserois import BaseRois
 from .binaryimaging import BinaryImaging, read_binary
 from .binaryrois import BinaryFolderRois, BinaryRois
 from .generators import generate_imaging_with_rois, generate_random_imaging, generate_rois
+from .geometry import geometry_table
 from .loading import load
 from .motion import Motion
-from .multifield import FieldGeometry, MultiFieldImaging
+from .multifield import fields_containing_point, get_field
 from .numpyimaging import NumpyImaging
 from .roianalyzer import (
     AnalyzerExtension,
-    MultiFieldRoiAnalyzer,
     RoiAnalyzer,
-    create_multifield_roi_analyzer,
     create_roi_analyzer,
     load_roi_analyzer,
     register_result_extension,

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -5,10 +5,13 @@ from .binaryrois import BinaryFolderRois, BinaryRois
 from .generators import generate_imaging_with_rois, generate_random_imaging, generate_rois
 from .loading import load
 from .motion import Motion
+from .multifield import FieldGeometry, MultiFieldImaging
 from .numpyimaging import NumpyImaging
 from .roianalyzer import (
     AnalyzerExtension,
+    MultiFieldRoiAnalyzer,
     RoiAnalyzer,
+    create_multifield_roi_analyzer,
     create_roi_analyzer,
     load_roi_analyzer,
     register_result_extension,

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -29,6 +29,7 @@ class BaseImaging(BaseExtractor, TimeSeries):
         self._sampling_frequency = float(sampling_frequency)
         self._shape = tuple(shape)  # Image is intended as a volume (H, W, planes)
         self._average_image = None
+        self._geometry: dict | None = None
 
     def _repr_header(self, display_name=True):
         """Generate text representation of the BaseImaging object."""
@@ -63,7 +64,7 @@ class BaseImaging(BaseExtractor, TimeSeries):
 
         # Format shape string based on whether data is volumetric or not
         shape_repr = f"{shape[0]} rows x {shape[1]} columns "
-        return (
+        header = (
             f"{name}:\n"
             f"{sampling_frequency_repr} - "
             f"{self.get_num_epochs()} epochs - "
@@ -72,6 +73,12 @@ class BaseImaging(BaseExtractor, TimeSeries):
             f"{dtype} dtype - "
             f"{memory_repr}"
         )
+        # Show placement only for fields that carry geometry (multi-field acquisitions).
+        if self._geometry is not None:
+            field_name = self._geometry.get("name")
+            center_xy = self._geometry.get("center_xy")
+            header += f"\n  geometry: name={field_name!r} center_xy={center_xy}"
+        return header
 
     def __repr__(self):
         return self._repr_header()
@@ -120,6 +127,35 @@ class BaseImaging(BaseExtractor, TimeSeries):
             The shape of the images as (height, width).
         """
         return self._shape
+
+    @property
+    def geometry(self) -> dict | None:
+        """Optional spatial-placement metadata for this imaging field.
+
+        A free-form dictionary describing where the field sits in the sample, or ``None`` when
+        unknown. It is populated for multi-field (e.g. mesoscope) acquisitions, where each field is an
+        independent :class:`BaseImaging` with its own pixel grid and physical position; a plain
+        single-field imaging leaves it ``None`` and is unaffected.
+
+        Conventional keys, all optional: ``name`` (str), ``uuid`` (str), ``center_xy`` and ``size_xy``
+        (in-plane center / extent in the source's physical units, e.g. scanner-angle units for
+        ScanImage), ``affine`` (3x3 pixel-to-physical transform) and ``microns_per_scanner_unit``
+        (physical-unit-to-micron scale). Depth is not stored here: it belongs to the field's own plane
+        axis, set as a per-plane ``z`` property.
+
+        Returns
+        -------
+        dict | None
+            The geometry dictionary, or None if unset.
+        """
+        return self._geometry
+
+    @geometry.setter
+    def geometry(self, value: dict | None) -> None:
+        """Set the geometry dictionary, accepting a dict or None."""
+        if value is not None and not isinstance(value, dict):
+            raise TypeError(f"geometry must be a dict or None, got {type(value).__name__}")
+        self._geometry = value
 
     @property
     def plane_ids(self):

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -29,7 +29,6 @@ class BaseImaging(BaseExtractor, TimeSeries):
         self._sampling_frequency = float(sampling_frequency)
         self._shape = tuple(shape)  # Image is intended as a volume (H, W, planes)
         self._average_image = None
-        self._geometry: dict | None = None
 
     def _repr_header(self, display_name=True):
         """Generate text representation of the BaseImaging object."""
@@ -74,10 +73,9 @@ class BaseImaging(BaseExtractor, TimeSeries):
             f"{memory_repr}"
         )
         # Show placement only for fields that carry geometry (multi-field acquisitions).
-        if self._geometry is not None:
-            field_name = self._geometry.get("name")
-            center_xy = self._geometry.get("center_xy")
-            header += f"\n  geometry: name={field_name!r} center_xy={center_xy}"
+        geometry = self.geometry
+        if geometry is not None:
+            header += f"\n  geometry: name={geometry.get('name')!r} center_xy={geometry.get('center_xy')}"
         return header
 
     def __repr__(self):
@@ -137,25 +135,30 @@ class BaseImaging(BaseExtractor, TimeSeries):
         independent :class:`BaseImaging` with its own pixel grid and physical position; a plain
         single-field imaging leaves it ``None`` and is unaffected.
 
+        Stored as the SpikeInterface annotation ``"geometry"``, so it travels through save / load with
+        the extractor. Its contents must therefore be JSON-serializable: use lists rather than numpy
+        arrays (e.g. ``affine`` as a 3x3 list of lists). Reads return a copy, so mutating the returned
+        dict in place does not persist; assign a new dict instead.
+
         Conventional keys, all optional: ``name`` (str), ``uuid`` (str), ``center_xy`` and ``size_xy``
         (in-plane center / extent in the source's physical units, e.g. scanner-angle units for
-        ScanImage), ``affine`` (3x3 pixel-to-physical transform) and ``microns_per_scanner_unit``
-        (physical-unit-to-micron scale). Depth is not stored here: it belongs to the field's own plane
-        axis, set as a per-plane ``z`` property.
+        ScanImage), ``affine`` (3x3 pixel-to-physical transform as a list of lists) and
+        ``microns_per_scanner_unit`` (physical-unit-to-micron scale). Depth is not stored here: it
+        belongs to the field's own plane axis, set as a per-plane ``z`` property.
 
         Returns
         -------
         dict | None
             The geometry dictionary, or None if unset.
         """
-        return self._geometry
+        return self.get_annotation("geometry")
 
     @geometry.setter
     def geometry(self, value: dict | None) -> None:
-        """Set the geometry dictionary, accepting a dict or None."""
+        """Set the geometry dictionary (stored as the ``"geometry"`` annotation); accepts a dict or None."""
         if value is not None and not isinstance(value, dict):
             raise TypeError(f"geometry must be a dict or None, got {type(value).__name__}")
-        self._geometry = value
+        self.set_annotation("geometry", value, overwrite=True)
 
     @property
     def plane_ids(self):

--- a/src/photon_mosaic/core/geometry.py
+++ b/src/photon_mosaic/core/geometry.py
@@ -1,0 +1,85 @@
+"""Helpers for the per-field ``geometry`` metadata carried by :class:`BaseImaging`.
+
+Multi-field (e.g. mesoscope) acquisitions attach a spatial-placement dictionary to each field's
+:class:`BaseImaging` via its :attr:`~photon_mosaic.core.baseimaging.BaseImaging.geometry` attribute
+(see that property for the conventional keys). This module reads across a collection of such fields:
+:func:`geometry_table` tabulates their placement. Geometry *validation* (checking a geometry dict's
+keys, types and array shapes) is intended to live here too and will be added alongside.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .baseimaging import BaseImaging
+
+
+def _to_microns(
+    value_xy: tuple[float, float] | None,
+    microns_per_scanner_unit: float | None,
+) -> tuple[float | None, float | None]:
+    """Scale an ``(x, y)`` scanner-unit pair to microns, or ``(None, None)`` if either input is missing."""
+    if value_xy is None or microns_per_scanner_unit is None:
+        return (None, None)
+    return (value_xy[0] * microns_per_scanner_unit, value_xy[1] * microns_per_scanner_unit)
+
+
+def geometry_table(imagings: Sequence[BaseImaging]):
+    """Tabulate the per-field geometry of a collection of imaging fields, one row per field.
+
+    Pixel shape, plane count, frame count and sampling frequency are read from each field itself;
+    identity and lateral placement (``name``, ``uuid``, ``center_xy``, ``size_xy``) from its
+    ``geometry`` dict, with matching micron columns derived from ``microns_per_scanner_unit`` when
+    present. The row ``index`` is the field's position in ``imagings``. The 3x3 ``affine`` is omitted
+    for readability (reach it via ``imagings[i].geometry["affine"]``). Fields with no geometry get
+    null placement columns.
+
+    Parameters
+    ----------
+    imagings : Sequence[BaseImaging]
+        The imaging fields to tabulate.
+
+    Returns
+    -------
+    pandas.DataFrame | list[dict]
+        A ``pandas.DataFrame`` if pandas is available, otherwise a list of row dicts.
+    """
+    rows = []
+    for index, imaging in enumerate(imagings):
+        geometry = imaging.geometry or {}
+        center_xy = geometry.get("center_xy")
+        size_xy = geometry.get("size_xy")
+        microns_per_scanner_unit = geometry.get("microns_per_scanner_unit")
+        center_x, center_y = center_xy if center_xy is not None else (None, None)
+        size_x, size_y = size_xy if size_xy is not None else (None, None)
+        # Micron columns mirror the scanner-unit ones, populated only when the scale is known.
+        center_x_um, center_y_um = _to_microns(center_xy, microns_per_scanner_unit)
+        size_x_um, size_y_um = _to_microns(size_xy, microns_per_scanner_unit)
+        height, width = imaging.shape[:2]
+        rows.append(
+            dict(
+                index=index,
+                name=geometry.get("name"),
+                uuid=geometry.get("uuid"),
+                height=height,
+                width=width,
+                num_planes=imaging.num_planes,
+                num_frames=imaging.get_total_frames(),
+                sampling_frequency=round(imaging.sampling_frequency, 4),
+                center_x=center_x,
+                center_y=center_y,
+                size_x=size_x,
+                size_y=size_y,
+                center_x_um=center_x_um,
+                center_y_um=center_y_um,
+                size_x_um=size_x_um,
+                size_y_um=size_y_um,
+            )
+        )
+    try:
+        import pandas as pd
+
+        return pd.DataFrame(rows)
+    except ImportError:
+        # Fall back to a plain list of row dicts when pandas is unavailable.
+        return rows

--- a/src/photon_mosaic/core/multifield.py
+++ b/src/photon_mosaic/core/multifield.py
@@ -1,0 +1,257 @@
+"""Container for imaging fields that do not share a common pixel grid.
+
+A multi-plane :class:`BaseImaging` is a *regular* volume: every plane shares one ``(height, width)``
+pixel grid and the plane axis is a regularly sampled depth. Some acquisitions (e.g. mesoscope
+multi-ROI recordings) instead capture several independent fields of view, each with its own pixel
+shape and physical position. These cannot be honestly stacked into a single ``BaseImaging``.
+
+:class:`MultiFieldImaging` keeps each field as its own :class:`BaseImaging` and records its lateral
+placement in a parallel :class:`FieldGeometry` table. The two kinds of multiplicity live on two
+levels:
+
+* within a field — the ``planes`` axis of one ``BaseImaging`` (a regular z-stack);
+* across fields — this container (free pixel shape, free lateral position).
+
+A field that is itself a z-stack is simply a ``BaseImaging`` with ``num_planes > 1``, so multiple
+z-stacks compose through the same container. Depth therefore belongs to a field's own plane axis,
+not to the container; :class:`FieldGeometry` carries only lateral placement and identity. There is
+deliberately no volume/stack view: the fields do not form a regular grid.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import Iterator
+
+import numpy as np
+
+from .baseimaging import BaseImaging
+
+
+@dataclass
+class FieldGeometry:
+    """Identity and lateral placement of one imaging field within the sample.
+
+    Spatial quantities are stored in the source's physical reference units (for ScanImage, scanner
+    angle units), not pixels. When the microns-per-unit scale is known, the ``center_xy`` / ``size_xy``
+    values are also available in micrometers through the :attr:`center_xy_um` / :attr:`size_xy_um`
+    properties, which derive from a single stored scale so the two representations cannot drift. Depth
+    (``z``) is intentionally absent: it varies across a field's planes and therefore belongs to the
+    field's own plane axis, not to this per-field record.
+
+    Attributes
+    ----------
+    index : int
+        The source-assigned field index.
+    name : str | None
+        Human-readable field name. Not guaranteed unique.
+    uuid : str | None
+        Unique field identifier, when the source provides one.
+    center_xy : tuple[float, float] | None
+        In-plane physical center of the field, in scanner-angle units.
+    size_xy : tuple[float, float] | None
+        In-plane physical extent of the field, in scanner-angle units.
+    affine : np.ndarray | None
+        3x3 pixel-to-physical (in-plane) transform, in scanner-angle units.
+    microns_per_scanner_unit : float | None
+        Micrometers subtended by one scanner-angle unit (for ScanImage, ``SI.objectiveResolution``).
+        Set when known; the ``*_um`` properties use it to convert the scanner-unit geometry to microns.
+    """
+
+    index: int
+    name: str | None = None
+    uuid: str | None = None
+    center_xy: tuple[float, float] | None = None
+    size_xy: tuple[float, float] | None = None
+    affine: np.ndarray | None = None
+    microns_per_scanner_unit: float | None = None
+
+    @property
+    def center_xy_um(self) -> tuple[float, float] | None:
+        """In-plane physical center in micrometers, or None if the center or scale is unknown."""
+        return self._to_microns(self.center_xy)
+
+    @property
+    def size_xy_um(self) -> tuple[float, float] | None:
+        """In-plane physical extent in micrometers, or None if the size or scale is unknown."""
+        return self._to_microns(self.size_xy)
+
+    def _to_microns(self, value_xy: tuple[float, float] | None) -> tuple[float, float] | None:
+        """Scale an (x, y) scanner-unit pair to micrometers, or None if either input is unavailable."""
+        if value_xy is None or self.microns_per_scanner_unit is None:
+            return None
+        return (value_xy[0] * self.microns_per_scanner_unit, value_xy[1] * self.microns_per_scanner_unit)
+
+
+def _resolve_field_selector(
+    geometry: list[FieldGeometry],
+    *,
+    index: int | None = None,
+    name: str | None = None,
+    uuid: str | None = None,
+) -> int:
+    """Resolve exactly one of index/name/uuid to a field position within ``geometry``.
+
+    uuid is matched case-insensitively. Raises ``ValueError`` if not exactly one selector is given or
+    a name/uuid is ambiguous, and ``KeyError`` if a name/uuid matches nothing.
+    """
+    if sum(selector is not None for selector in (index, name, uuid)) != 1:
+        raise ValueError("pass exactly one of index, name, or uuid")
+    if index is not None:
+        return index
+    if uuid is not None:
+        matches = [i for i, geom in enumerate(geometry) if (geom.uuid or "").lower() == uuid.lower()]
+    else:
+        matches = [i for i, geom in enumerate(geometry) if geom.name == name]
+
+    selector_kind, selector_value = ("uuid", uuid) if uuid is not None else ("name", name)
+    if not matches:
+        raise KeyError(f"no field matching {selector_kind}={selector_value!r}")
+    if len(matches) > 1:
+        raise ValueError(f"{selector_kind}={selector_value!r} is ambiguous: indices {matches}")
+    return matches[0]
+
+
+class MultiFieldImaging:
+    """A collection of imaging fields with independent pixel grids and physical positions.
+
+    Each field is a standalone :class:`BaseImaging`, so every per-field capability (ROIs,
+    ``RoiAnalyzer``, fluorescence) applies unchanged. The container adds cohesion: shared identity,
+    selection by index/name/uuid, and a geometry table describing where each field is located in
+    space.
+    """
+
+    def __init__(self, fields: list[BaseImaging], geometry: list[FieldGeometry]) -> None:
+        """Pair a list of field imagings with their geometry records.
+
+        Parameters
+        ----------
+        fields : list[BaseImaging]
+            One imaging object per field.
+        geometry : list[FieldGeometry]
+            Placement records, aligned by position with ``fields``.
+        """
+        if len(fields) != len(geometry):
+            raise ValueError(f"fields ({len(fields)}) and geometry ({len(geometry)}) length mismatch")
+
+        # Each field must be a real imaging container; the geometry table only places it in space.
+        for field in fields:
+            if not isinstance(field, BaseImaging):
+                raise TypeError(f"each field must be a BaseImaging, got {type(field).__name__}")
+
+        # Fields are expected to be co-acquired (one shared timebase); flag a mixed set rather than fail.
+        sampling_frequencies = {round(field.sampling_frequency, 4) for field in fields}
+        if len(sampling_frequencies) > 1:
+            warnings.warn(
+                f"fields have heterogeneous sampling frequencies: {sorted(sampling_frequencies)}",
+                UserWarning,
+            )
+
+        self._fields = list(fields)
+        self._geometry = list(geometry)
+
+    def __len__(self) -> int:
+        """Return the number of fields."""
+        return len(self._fields)
+
+    def __iter__(self) -> Iterator[BaseImaging]:
+        """Iterate over the field imagings."""
+        return iter(self._fields)
+
+    def __getitem__(self, index: int | slice) -> BaseImaging | list[BaseImaging]:
+        """Index fields by position (int or slice)."""
+        return self._fields[index]
+
+    @property
+    def fields(self) -> list[BaseImaging]:
+        """The per-field imaging objects."""
+        return self._fields
+
+    @property
+    def geometry(self) -> list[FieldGeometry]:
+        """The per-field geometry records, aligned with :attr:`fields`."""
+        return self._geometry
+
+    def iter_fields(self) -> Iterator[tuple[FieldGeometry, BaseImaging]]:
+        """Iterate over ``(geometry, imaging)`` pairs."""
+        return zip(self._geometry, self._fields)
+
+    def get_field(
+        self,
+        *,
+        index: int | None = None,
+        name: str | None = None,
+        uuid: str | None = None,
+    ) -> BaseImaging:
+        """Return a single field selected by exactly one of index, name, or uuid.
+
+        Parameters
+        ----------
+        index : int | None
+            Position of the field.
+        name : str | None
+            Field name. Names are not guaranteed unique; an ambiguous name raises ``ValueError``.
+        uuid : str | None
+            Field uuid, matched case-insensitively (the robust selector).
+
+        Returns
+        -------
+        BaseImaging
+            The selected field.
+        """
+        return self._fields[_resolve_field_selector(self._geometry, index=index, name=name, uuid=uuid)]
+
+    def geometry_table(self):
+        """Return the geometry as a table.
+
+        Returns a ``pandas.DataFrame`` if pandas is available, otherwise a list of row dicts. Pixel
+        shape, frame count, and sampling frequency are read from the fields themselves; the 3x3
+        affine is omitted for readability (reach it via ``self.geometry[i].affine``).
+        """
+        rows = []
+        for geom, field in self.iter_fields():
+            center_x, center_y = geom.center_xy if geom.center_xy is not None else (None, None)
+            size_x, size_y = geom.size_xy if geom.size_xy is not None else (None, None)
+            # Micron columns mirror the scanner-unit ones, populated only when the scale is known.
+            center_x_um, center_y_um = geom.center_xy_um if geom.center_xy_um is not None else (None, None)
+            size_x_um, size_y_um = geom.size_xy_um if geom.size_xy_um is not None else (None, None)
+            height, width = field.shape[:2]
+            rows.append(
+                dict(
+                    index=geom.index,
+                    name=geom.name,
+                    uuid=geom.uuid,
+                    height=height,
+                    width=width,
+                    num_planes=field.num_planes,
+                    num_frames=field.get_total_frames(),
+                    sampling_frequency=round(field.sampling_frequency, 4),
+                    center_x=center_x,
+                    center_y=center_y,
+                    size_x=size_x,
+                    size_y=size_y,
+                    center_x_um=center_x_um,
+                    center_y_um=center_y_um,
+                    size_x_um=size_x_um,
+                    size_y_um=size_y_um,
+                )
+            )
+        try:
+            import pandas as pd
+
+            return pd.DataFrame(rows)
+        except ImportError:
+            # Fall back to a plain list of row dicts when pandas is unavailable.
+            return rows
+
+    def __repr__(self) -> str:
+        lines = [f"MultiFieldImaging: {len(self)} fields"]
+        for geom, field in self.iter_fields():
+            height, width = field.shape[:2]
+            lines.append(
+                f"  [{geom.index}] {geom.name!r} uuid={geom.uuid} "
+                f"{height}x{width}px x{field.num_planes} planes "
+                f"center_xy={geom.center_xy} size_xy={geom.size_xy}"
+            )
+        return "\n".join(lines)

--- a/src/photon_mosaic/core/multifield.py
+++ b/src/photon_mosaic/core/multifield.py
@@ -1,257 +1,102 @@
-"""Container for imaging fields that do not share a common pixel grid.
+"""Helpers over a collection of imaging fields (a ``Sequence[BaseImaging]``).
 
-A multi-plane :class:`BaseImaging` is a *regular* volume: every plane shares one ``(height, width)``
-pixel grid and the plane axis is a regularly sampled depth. Some acquisitions (e.g. mesoscope
-multi-ROI recordings) instead capture several independent fields of view, each with its own pixel
-shape and physical position. These cannot be honestly stacked into a single ``BaseImaging``.
-
-:class:`MultiFieldImaging` keeps each field as its own :class:`BaseImaging` and records its lateral
-placement in a parallel :class:`FieldGeometry` table. The two kinds of multiplicity live on two
-levels:
-
-* within a field — the ``planes`` axis of one ``BaseImaging`` (a regular z-stack);
-* across fields — this container (free pixel shape, free lateral position).
-
-A field that is itself a z-stack is simply a ``BaseImaging`` with ``num_planes > 1``, so multiple
-z-stacks compose through the same container. Depth therefore belongs to a field's own plane axis,
-not to the container; :class:`FieldGeometry` carries only lateral placement and identity. There is
-deliberately no volume/stack view: the fields do not form a regular grid.
+Multi-field (e.g. mesoscope) acquisitions are represented as a plain sequence of independent
+:class:`BaseImaging` objects, each carrying its own spatial placement in its ``geometry`` dict (see
+:attr:`~photon_mosaic.core.baseimaging.BaseImaging.geometry`). No container object is needed — a list
+already provides length, iteration and indexing. This module adds the operations a bare sequence does
+not: selecting a field by identity now, and (planned) selecting fields by spatial location.
 """
 
 from __future__ import annotations
 
-import warnings
-from dataclasses import dataclass
-from typing import Iterator
-
-import numpy as np
+from typing import Sequence
 
 from .baseimaging import BaseImaging
 
 
-@dataclass
-class FieldGeometry:
-    """Identity and lateral placement of one imaging field within the sample.
-
-    Spatial quantities are stored in the source's physical reference units (for ScanImage, scanner
-    angle units), not pixels. When the microns-per-unit scale is known, the ``center_xy`` / ``size_xy``
-    values are also available in micrometers through the :attr:`center_xy_um` / :attr:`size_xy_um`
-    properties, which derive from a single stored scale so the two representations cannot drift. Depth
-    (``z``) is intentionally absent: it varies across a field's planes and therefore belongs to the
-    field's own plane axis, not to this per-field record.
-
-    Attributes
-    ----------
-    index : int
-        The source-assigned field index.
-    name : str | None
-        Human-readable field name. Not guaranteed unique.
-    uuid : str | None
-        Unique field identifier, when the source provides one.
-    center_xy : tuple[float, float] | None
-        In-plane physical center of the field, in scanner-angle units.
-    size_xy : tuple[float, float] | None
-        In-plane physical extent of the field, in scanner-angle units.
-    affine : np.ndarray | None
-        3x3 pixel-to-physical (in-plane) transform, in scanner-angle units.
-    microns_per_scanner_unit : float | None
-        Micrometers subtended by one scanner-angle unit (for ScanImage, ``SI.objectiveResolution``).
-        Set when known; the ``*_um`` properties use it to convert the scanner-unit geometry to microns.
-    """
-
-    index: int
-    name: str | None = None
-    uuid: str | None = None
-    center_xy: tuple[float, float] | None = None
-    size_xy: tuple[float, float] | None = None
-    affine: np.ndarray | None = None
-    microns_per_scanner_unit: float | None = None
-
-    @property
-    def center_xy_um(self) -> tuple[float, float] | None:
-        """In-plane physical center in micrometers, or None if the center or scale is unknown."""
-        return self._to_microns(self.center_xy)
-
-    @property
-    def size_xy_um(self) -> tuple[float, float] | None:
-        """In-plane physical extent in micrometers, or None if the size or scale is unknown."""
-        return self._to_microns(self.size_xy)
-
-    def _to_microns(self, value_xy: tuple[float, float] | None) -> tuple[float, float] | None:
-        """Scale an (x, y) scanner-unit pair to micrometers, or None if either input is unavailable."""
-        if value_xy is None or self.microns_per_scanner_unit is None:
-            return None
-        return (value_xy[0] * self.microns_per_scanner_unit, value_xy[1] * self.microns_per_scanner_unit)
+def _geometry_value(imaging: BaseImaging, key: str):
+    """Return ``imaging.geometry[key]``, or None when the field has no geometry or lacks the key."""
+    return (imaging.geometry or {}).get(key)
 
 
-def _resolve_field_selector(
-    geometry: list[FieldGeometry],
+def get_field(
+    imagings: Sequence[BaseImaging],
     *,
     index: int | None = None,
     name: str | None = None,
     uuid: str | None = None,
-) -> int:
-    """Resolve exactly one of index/name/uuid to a field position within ``geometry``.
+) -> BaseImaging:
+    """Select a single field from ``imagings`` by exactly one of index, name, or uuid.
 
-    uuid is matched case-insensitively. Raises ``ValueError`` if not exactly one selector is given or
-    a name/uuid is ambiguous, and ``KeyError`` if a name/uuid matches nothing.
+    ``name`` and ``uuid`` are read from each field's ``geometry`` dict; ``uuid`` is matched
+    case-insensitively (the robust selector, since names are not guaranteed unique). ``index`` is the
+    field's position in ``imagings``.
+
+    Parameters
+    ----------
+    imagings : Sequence[BaseImaging]
+        The imaging fields to select from.
+    index : int | None
+        Position of the field.
+    name : str | None
+        Field name. An ambiguous name raises ``ValueError``.
+    uuid : str | None
+        Field uuid, matched case-insensitively.
+
+    Returns
+    -------
+    BaseImaging
+        The selected field.
+
+    Raises
+    ------
+    ValueError
+        If not exactly one of index/name/uuid is given, or a name/uuid is ambiguous.
+    KeyError
+        If a name/uuid matches no field.
     """
     if sum(selector is not None for selector in (index, name, uuid)) != 1:
         raise ValueError("pass exactly one of index, name, or uuid")
     if index is not None:
-        return index
-    if uuid is not None:
-        matches = [i for i, geom in enumerate(geometry) if (geom.uuid or "").lower() == uuid.lower()]
-    else:
-        matches = [i for i, geom in enumerate(geometry) if geom.name == name]
+        return imagings[index]
 
-    selector_kind, selector_value = ("uuid", uuid) if uuid is not None else ("name", name)
+    if uuid is not None:
+        matches = [i for i, im in enumerate(imagings) if (_geometry_value(im, "uuid") or "").lower() == uuid.lower()]
+        selector_kind, selector_value = "uuid", uuid
+    else:
+        # Reaching here means index and uuid are None, so the exactly-one guard leaves name set.
+        assert name is not None
+        matches = [i for i, im in enumerate(imagings) if _geometry_value(im, "name") == name]
+        selector_kind, selector_value = "name", name
+
     if not matches:
         raise KeyError(f"no field matching {selector_kind}={selector_value!r}")
     if len(matches) > 1:
         raise ValueError(f"{selector_kind}={selector_value!r} is ambiguous: indices {matches}")
-    return matches[0]
+    return imagings[matches[0]]
 
 
-class MultiFieldImaging:
-    """A collection of imaging fields with independent pixel grids and physical positions.
+def fields_containing_point(
+    imagings: Sequence[BaseImaging],
+    point_xy: tuple[float, float],
+) -> list[BaseImaging]:
+    """Return the fields whose lateral extent contains ``point_xy``.  [PLANNED — not implemented]
 
-    Each field is a standalone :class:`BaseImaging`, so every per-field capability (ROIs,
-    ``RoiAnalyzer``, fluorescence) applies unchanged. The container adds cohesion: shared identity,
-    selection by index/name/uuid, and a geometry table describing where each field is located in
-    space.
+    Intended to test ``point_xy`` (in the fields' physical reference units) against each field's
+    in-plane bounds derived from its ``geometry`` — ``center_xy`` / ``size_xy`` for an axis-aligned
+    extent, or the ``affine`` for a rotated one — and return those that contain it. Not implemented
+    yet.
+
+    Parameters
+    ----------
+    imagings : Sequence[BaseImaging]
+        The imaging fields to test.
+    point_xy : tuple[float, float]
+        The in-plane query point, in the fields' physical reference units.
+
+    Returns
+    -------
+    list[BaseImaging]
+        The fields whose extent contains the point.
     """
-
-    def __init__(self, fields: list[BaseImaging], geometry: list[FieldGeometry]) -> None:
-        """Pair a list of field imagings with their geometry records.
-
-        Parameters
-        ----------
-        fields : list[BaseImaging]
-            One imaging object per field.
-        geometry : list[FieldGeometry]
-            Placement records, aligned by position with ``fields``.
-        """
-        if len(fields) != len(geometry):
-            raise ValueError(f"fields ({len(fields)}) and geometry ({len(geometry)}) length mismatch")
-
-        # Each field must be a real imaging container; the geometry table only places it in space.
-        for field in fields:
-            if not isinstance(field, BaseImaging):
-                raise TypeError(f"each field must be a BaseImaging, got {type(field).__name__}")
-
-        # Fields are expected to be co-acquired (one shared timebase); flag a mixed set rather than fail.
-        sampling_frequencies = {round(field.sampling_frequency, 4) for field in fields}
-        if len(sampling_frequencies) > 1:
-            warnings.warn(
-                f"fields have heterogeneous sampling frequencies: {sorted(sampling_frequencies)}",
-                UserWarning,
-            )
-
-        self._fields = list(fields)
-        self._geometry = list(geometry)
-
-    def __len__(self) -> int:
-        """Return the number of fields."""
-        return len(self._fields)
-
-    def __iter__(self) -> Iterator[BaseImaging]:
-        """Iterate over the field imagings."""
-        return iter(self._fields)
-
-    def __getitem__(self, index: int | slice) -> BaseImaging | list[BaseImaging]:
-        """Index fields by position (int or slice)."""
-        return self._fields[index]
-
-    @property
-    def fields(self) -> list[BaseImaging]:
-        """The per-field imaging objects."""
-        return self._fields
-
-    @property
-    def geometry(self) -> list[FieldGeometry]:
-        """The per-field geometry records, aligned with :attr:`fields`."""
-        return self._geometry
-
-    def iter_fields(self) -> Iterator[tuple[FieldGeometry, BaseImaging]]:
-        """Iterate over ``(geometry, imaging)`` pairs."""
-        return zip(self._geometry, self._fields)
-
-    def get_field(
-        self,
-        *,
-        index: int | None = None,
-        name: str | None = None,
-        uuid: str | None = None,
-    ) -> BaseImaging:
-        """Return a single field selected by exactly one of index, name, or uuid.
-
-        Parameters
-        ----------
-        index : int | None
-            Position of the field.
-        name : str | None
-            Field name. Names are not guaranteed unique; an ambiguous name raises ``ValueError``.
-        uuid : str | None
-            Field uuid, matched case-insensitively (the robust selector).
-
-        Returns
-        -------
-        BaseImaging
-            The selected field.
-        """
-        return self._fields[_resolve_field_selector(self._geometry, index=index, name=name, uuid=uuid)]
-
-    def geometry_table(self):
-        """Return the geometry as a table.
-
-        Returns a ``pandas.DataFrame`` if pandas is available, otherwise a list of row dicts. Pixel
-        shape, frame count, and sampling frequency are read from the fields themselves; the 3x3
-        affine is omitted for readability (reach it via ``self.geometry[i].affine``).
-        """
-        rows = []
-        for geom, field in self.iter_fields():
-            center_x, center_y = geom.center_xy if geom.center_xy is not None else (None, None)
-            size_x, size_y = geom.size_xy if geom.size_xy is not None else (None, None)
-            # Micron columns mirror the scanner-unit ones, populated only when the scale is known.
-            center_x_um, center_y_um = geom.center_xy_um if geom.center_xy_um is not None else (None, None)
-            size_x_um, size_y_um = geom.size_xy_um if geom.size_xy_um is not None else (None, None)
-            height, width = field.shape[:2]
-            rows.append(
-                dict(
-                    index=geom.index,
-                    name=geom.name,
-                    uuid=geom.uuid,
-                    height=height,
-                    width=width,
-                    num_planes=field.num_planes,
-                    num_frames=field.get_total_frames(),
-                    sampling_frequency=round(field.sampling_frequency, 4),
-                    center_x=center_x,
-                    center_y=center_y,
-                    size_x=size_x,
-                    size_y=size_y,
-                    center_x_um=center_x_um,
-                    center_y_um=center_y_um,
-                    size_x_um=size_x_um,
-                    size_y_um=size_y_um,
-                )
-            )
-        try:
-            import pandas as pd
-
-            return pd.DataFrame(rows)
-        except ImportError:
-            # Fall back to a plain list of row dicts when pandas is unavailable.
-            return rows
-
-    def __repr__(self) -> str:
-        lines = [f"MultiFieldImaging: {len(self)} fields"]
-        for geom, field in self.iter_fields():
-            height, width = field.shape[:2]
-            lines.append(
-                f"  [{geom.index}] {geom.name!r} uuid={geom.uuid} "
-                f"{height}x{width}px x{field.num_planes} planes "
-                f"center_xy={geom.center_xy} size_xy={geom.size_xy}"
-            )
-        return "\n".join(lines)
+    raise NotImplementedError("spatial field selection is not implemented yet")

--- a/src/photon_mosaic/core/roianalyzer.py
+++ b/src/photon_mosaic/core/roianalyzer.py
@@ -16,7 +16,7 @@ from copy import copy
 from itertools import chain
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Iterator, Literal
+from typing import Any, Literal
 
 import numpy as np
 from spikeinterface.core.core_tools import (
@@ -33,66 +33,12 @@ from .baseimaging import BaseImaging
 from .baserois import BaseRois
 from .binaryrois import BinaryFolderRois
 from .imaging_tools import do_imaging_attributes_match, get_imaging_attributes
-from .multifield import FieldGeometry, MultiFieldImaging, _resolve_field_selector
 from .numpyimaging import NumpyRois
 from .zarrrois import ZarrRois, save_rois_to_zarr
 
 # ---------------------------------------------------------------------------
 # High-level factory functions
 # ---------------------------------------------------------------------------
-
-
-def create_multifield_roi_analyzer(
-    rois: list[BaseRois],
-    multiimaging: MultiFieldImaging,
-    format: str = "memory",
-    folder=None,
-    overwrite: bool = False,
-    backend_options: dict | None = None,
-) -> "MultiFieldRoiAnalyzer":
-    """Create one RoiAnalyzer per field by pairing ROIs with a MultiFieldImaging.
-
-    The multi-field counterpart of :func:`create_roi_analyzer`. ``rois[i]`` is paired with field
-    ``i`` of ``multiimaging``, so the two must have the same length and ordering. The fields do not
-    share a pixel grid, so each pairing is its own independent RoiAnalyzer; the per-field analyzers
-    are returned together in a :class:`MultiFieldRoiAnalyzer` container.
-
-    Parameters
-    ----------
-    rois : list[BaseRois]
-        One ROIs object per field, ordered to match ``multiimaging``.
-    multiimaging : MultiFieldImaging
-        The container of imaging fields.
-    format : "memory" | "binary_folder" | "zarr", default: "memory"
-        The storage backend. For non-memory formats ``folder`` is treated as a parent directory and
-        each field is persisted in its own ``field_<i>`` subfolder so they do not collide.
-    folder : str | Path | None, default: None
-        Parent folder for the per-field analyzers (required for non-memory formats).
-    overwrite : bool, default: False
-        If True, overwrite each field's folder if it already exists.
-    backend_options : dict | None, default: None
-        Backend-specific options, forwarded to each :func:`create_roi_analyzer`.
-
-    Returns
-    -------
-    MultiFieldRoiAnalyzer
-        A container pairing one RoiAnalyzer per field with the geometry of ``multiimaging``,
-        aligned with ``rois``.
-    """
-    if len(rois) != len(multiimaging):
-        raise ValueError(f"number of rois ({len(rois)}) must match the number of fields ({len(multiimaging)})")
-    if format != "memory" and folder is None:
-        raise ValueError(f"folder must be provided for format={format!r}")
-
-    # Arguments forwarded unchanged to every per-field analyzer.
-    shared_kwargs: dict[str, Any] = dict(format=format, overwrite=overwrite, backend_options=backend_options)
-
-    roi_analyzers = []
-    for i, (field_rois, field_imaging) in enumerate(zip(rois, multiimaging)):
-        # Persist each field separately so non-memory backends do not collide on a single folder.
-        field_folder = None if folder is None else f"{str(folder).rstrip('/')}/field_{i:03d}"
-        roi_analyzers.append(create_roi_analyzer(field_rois, field_imaging, folder=field_folder, **shared_kwargs))
-    return MultiFieldRoiAnalyzer(roi_analyzers, list(multiimaging.geometry))
 
 
 def create_roi_analyzer(
@@ -1133,133 +1079,6 @@ class RoiAnalyzer:
     def get_default_extension_params(self, extension_name: str) -> dict:
         """Get default params for an extension."""
         return get_default_analyzer_extension_params(extension_name)
-
-
-# ---------------------------------------------------------------------------
-# MultiFieldRoiAnalyzer
-# ---------------------------------------------------------------------------
-
-
-class MultiFieldRoiAnalyzer:
-    """A collection of per-field RoiAnalyzers sharing one geometry table.
-
-    The analyzer-level counterpart of :class:`MultiFieldImaging`: each field keeps its own
-    independent :class:`RoiAnalyzer` (the fields do not share a pixel grid), while this container adds
-    cohesion — shared identity, selection by index/name/uuid, and the per-field geometry. Build one
-    with :func:`create_multifield_roi_analyzer`.
-    """
-
-    def __init__(self, analyzers: list[RoiAnalyzer], geometry: list[FieldGeometry]) -> None:
-        """Pair a list of per-field analyzers with their geometry records.
-
-        Parameters
-        ----------
-        analyzers : list[RoiAnalyzer]
-            One analyzer per field.
-        geometry : list[FieldGeometry]
-            Placement records, aligned by position with ``analyzers``.
-        """
-        if len(analyzers) != len(geometry):
-            raise ValueError(f"analyzers ({len(analyzers)}) and geometry ({len(geometry)}) length mismatch")
-
-        self._analyzers = list(analyzers)
-        self._geometry = list(geometry)
-
-    def __len__(self) -> int:
-        """Return the number of fields."""
-        return len(self._analyzers)
-
-    def __iter__(self) -> Iterator[RoiAnalyzer]:
-        """Iterate over the per-field analyzers."""
-        return iter(self._analyzers)
-
-    def __getitem__(self, index: int | slice) -> "RoiAnalyzer | list[RoiAnalyzer]":
-        """Index analyzers by position (int or slice)."""
-        return self._analyzers[index]
-
-    @property
-    def analyzers(self) -> list[RoiAnalyzer]:
-        """The per-field analyzers."""
-        return self._analyzers
-
-    @property
-    def geometry(self) -> list[FieldGeometry]:
-        """The per-field geometry records, aligned with :attr:`analyzers`."""
-        return self._geometry
-
-    def iter_fields(self) -> Iterator[tuple[FieldGeometry, RoiAnalyzer]]:
-        """Iterate over ``(geometry, analyzer)`` pairs."""
-        return zip(self._geometry, self._analyzers)
-
-    def get_analyzer(
-        self,
-        *,
-        index: int | None = None,
-        name: str | None = None,
-        uuid: str | None = None,
-    ) -> RoiAnalyzer:
-        """Return a single field's analyzer selected by exactly one of index, name, or uuid.
-
-        Selection semantics match :meth:`MultiFieldImaging.get_field`: uuid is matched
-        case-insensitively, an ambiguous name/uuid raises ``ValueError``, and an unknown one raises
-        ``KeyError``.
-
-        Parameters
-        ----------
-        index : int | None
-            Position of the field.
-        name : str | None
-            Field name (not guaranteed unique; an ambiguous name raises ``ValueError``).
-        uuid : str | None
-            Field uuid, matched case-insensitively (the robust selector).
-
-        Returns
-        -------
-        RoiAnalyzer
-            The selected field's analyzer.
-        """
-        return self._analyzers[_resolve_field_selector(self._geometry, index=index, name=name, uuid=uuid)]
-
-    def compute(
-        self,
-        input: str | dict | list,
-        save: bool = True,
-        extension_params: dict | None = None,
-        verbose: bool = False,
-        **kwargs,
-    ) -> None:
-        """Compute one or several extensions on every field.
-
-        A thin fan-out over the per-field analyzers: each receives the same ``input`` and parameters
-        via :meth:`RoiAnalyzer.compute`. Results stay on their own field's analyzer — reach them
-        through :meth:`get_analyzer` or :meth:`iter_fields`. Combining results across fields is
-        intentionally not done here.
-
-        Parameters
-        ----------
-        input : str | dict | list
-            Extension name, a ``{name: params}`` dict, or a list of names (see
-            :meth:`RoiAnalyzer.compute`).
-        save : bool, default: True
-            Whether each field persists its computed extensions.
-        extension_params : dict | None, default: None
-            Per-extension params when ``input`` is a list.
-        verbose : bool, default: False
-            Print progress.
-        **kwargs
-            Forwarded to each :meth:`RoiAnalyzer.compute` (e.g. job_kwargs for parallelization).
-        """
-        for analyzer in self._analyzers:
-            analyzer.compute(input, save=save, extension_params=extension_params, verbose=verbose, **kwargs)
-
-    def __repr__(self) -> str:
-        lines = [f"MultiFieldRoiAnalyzer: {len(self)} fields"]
-        for geom, analyzer in self.iter_fields():
-            extensions = ", ".join(analyzer.get_loaded_extension_names()) or "no extensions"
-            lines.append(
-                f"  [{geom.index}] {geom.name!r} uuid={geom.uuid} {analyzer.get_num_rois()} ROIs - {extensions}"
-            )
-        return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/src/photon_mosaic/core/roianalyzer.py
+++ b/src/photon_mosaic/core/roianalyzer.py
@@ -16,7 +16,7 @@ from copy import copy
 from itertools import chain
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Literal
+from typing import Any, Iterator, Literal
 
 import numpy as np
 from spikeinterface.core.core_tools import (
@@ -33,12 +33,66 @@ from .baseimaging import BaseImaging
 from .baserois import BaseRois
 from .binaryrois import BinaryFolderRois
 from .imaging_tools import do_imaging_attributes_match, get_imaging_attributes
+from .multifield import FieldGeometry, MultiFieldImaging, _resolve_field_selector
 from .numpyimaging import NumpyRois
 from .zarrrois import ZarrRois, save_rois_to_zarr
 
 # ---------------------------------------------------------------------------
 # High-level factory functions
 # ---------------------------------------------------------------------------
+
+
+def create_multifield_roi_analyzer(
+    rois: list[BaseRois],
+    multiimaging: MultiFieldImaging,
+    format: str = "memory",
+    folder=None,
+    overwrite: bool = False,
+    backend_options: dict | None = None,
+) -> "MultiFieldRoiAnalyzer":
+    """Create one RoiAnalyzer per field by pairing ROIs with a MultiFieldImaging.
+
+    The multi-field counterpart of :func:`create_roi_analyzer`. ``rois[i]`` is paired with field
+    ``i`` of ``multiimaging``, so the two must have the same length and ordering. The fields do not
+    share a pixel grid, so each pairing is its own independent RoiAnalyzer; the per-field analyzers
+    are returned together in a :class:`MultiFieldRoiAnalyzer` container.
+
+    Parameters
+    ----------
+    rois : list[BaseRois]
+        One ROIs object per field, ordered to match ``multiimaging``.
+    multiimaging : MultiFieldImaging
+        The container of imaging fields.
+    format : "memory" | "binary_folder" | "zarr", default: "memory"
+        The storage backend. For non-memory formats ``folder`` is treated as a parent directory and
+        each field is persisted in its own ``field_<i>`` subfolder so they do not collide.
+    folder : str | Path | None, default: None
+        Parent folder for the per-field analyzers (required for non-memory formats).
+    overwrite : bool, default: False
+        If True, overwrite each field's folder if it already exists.
+    backend_options : dict | None, default: None
+        Backend-specific options, forwarded to each :func:`create_roi_analyzer`.
+
+    Returns
+    -------
+    MultiFieldRoiAnalyzer
+        A container pairing one RoiAnalyzer per field with the geometry of ``multiimaging``,
+        aligned with ``rois``.
+    """
+    if len(rois) != len(multiimaging):
+        raise ValueError(f"number of rois ({len(rois)}) must match the number of fields ({len(multiimaging)})")
+    if format != "memory" and folder is None:
+        raise ValueError(f"folder must be provided for format={format!r}")
+
+    # Arguments forwarded unchanged to every per-field analyzer.
+    shared_kwargs: dict[str, Any] = dict(format=format, overwrite=overwrite, backend_options=backend_options)
+
+    roi_analyzers = []
+    for i, (field_rois, field_imaging) in enumerate(zip(rois, multiimaging)):
+        # Persist each field separately so non-memory backends do not collide on a single folder.
+        field_folder = None if folder is None else f"{str(folder).rstrip('/')}/field_{i:03d}"
+        roi_analyzers.append(create_roi_analyzer(field_rois, field_imaging, folder=field_folder, **shared_kwargs))
+    return MultiFieldRoiAnalyzer(roi_analyzers, list(multiimaging.geometry))
 
 
 def create_roi_analyzer(
@@ -1079,6 +1133,133 @@ class RoiAnalyzer:
     def get_default_extension_params(self, extension_name: str) -> dict:
         """Get default params for an extension."""
         return get_default_analyzer_extension_params(extension_name)
+
+
+# ---------------------------------------------------------------------------
+# MultiFieldRoiAnalyzer
+# ---------------------------------------------------------------------------
+
+
+class MultiFieldRoiAnalyzer:
+    """A collection of per-field RoiAnalyzers sharing one geometry table.
+
+    The analyzer-level counterpart of :class:`MultiFieldImaging`: each field keeps its own
+    independent :class:`RoiAnalyzer` (the fields do not share a pixel grid), while this container adds
+    cohesion — shared identity, selection by index/name/uuid, and the per-field geometry. Build one
+    with :func:`create_multifield_roi_analyzer`.
+    """
+
+    def __init__(self, analyzers: list[RoiAnalyzer], geometry: list[FieldGeometry]) -> None:
+        """Pair a list of per-field analyzers with their geometry records.
+
+        Parameters
+        ----------
+        analyzers : list[RoiAnalyzer]
+            One analyzer per field.
+        geometry : list[FieldGeometry]
+            Placement records, aligned by position with ``analyzers``.
+        """
+        if len(analyzers) != len(geometry):
+            raise ValueError(f"analyzers ({len(analyzers)}) and geometry ({len(geometry)}) length mismatch")
+
+        self._analyzers = list(analyzers)
+        self._geometry = list(geometry)
+
+    def __len__(self) -> int:
+        """Return the number of fields."""
+        return len(self._analyzers)
+
+    def __iter__(self) -> Iterator[RoiAnalyzer]:
+        """Iterate over the per-field analyzers."""
+        return iter(self._analyzers)
+
+    def __getitem__(self, index: int | slice) -> "RoiAnalyzer | list[RoiAnalyzer]":
+        """Index analyzers by position (int or slice)."""
+        return self._analyzers[index]
+
+    @property
+    def analyzers(self) -> list[RoiAnalyzer]:
+        """The per-field analyzers."""
+        return self._analyzers
+
+    @property
+    def geometry(self) -> list[FieldGeometry]:
+        """The per-field geometry records, aligned with :attr:`analyzers`."""
+        return self._geometry
+
+    def iter_fields(self) -> Iterator[tuple[FieldGeometry, RoiAnalyzer]]:
+        """Iterate over ``(geometry, analyzer)`` pairs."""
+        return zip(self._geometry, self._analyzers)
+
+    def get_analyzer(
+        self,
+        *,
+        index: int | None = None,
+        name: str | None = None,
+        uuid: str | None = None,
+    ) -> RoiAnalyzer:
+        """Return a single field's analyzer selected by exactly one of index, name, or uuid.
+
+        Selection semantics match :meth:`MultiFieldImaging.get_field`: uuid is matched
+        case-insensitively, an ambiguous name/uuid raises ``ValueError``, and an unknown one raises
+        ``KeyError``.
+
+        Parameters
+        ----------
+        index : int | None
+            Position of the field.
+        name : str | None
+            Field name (not guaranteed unique; an ambiguous name raises ``ValueError``).
+        uuid : str | None
+            Field uuid, matched case-insensitively (the robust selector).
+
+        Returns
+        -------
+        RoiAnalyzer
+            The selected field's analyzer.
+        """
+        return self._analyzers[_resolve_field_selector(self._geometry, index=index, name=name, uuid=uuid)]
+
+    def compute(
+        self,
+        input: str | dict | list,
+        save: bool = True,
+        extension_params: dict | None = None,
+        verbose: bool = False,
+        **kwargs,
+    ) -> None:
+        """Compute one or several extensions on every field.
+
+        A thin fan-out over the per-field analyzers: each receives the same ``input`` and parameters
+        via :meth:`RoiAnalyzer.compute`. Results stay on their own field's analyzer — reach them
+        through :meth:`get_analyzer` or :meth:`iter_fields`. Combining results across fields is
+        intentionally not done here.
+
+        Parameters
+        ----------
+        input : str | dict | list
+            Extension name, a ``{name: params}`` dict, or a list of names (see
+            :meth:`RoiAnalyzer.compute`).
+        save : bool, default: True
+            Whether each field persists its computed extensions.
+        extension_params : dict | None, default: None
+            Per-extension params when ``input`` is a list.
+        verbose : bool, default: False
+            Print progress.
+        **kwargs
+            Forwarded to each :meth:`RoiAnalyzer.compute` (e.g. job_kwargs for parallelization).
+        """
+        for analyzer in self._analyzers:
+            analyzer.compute(input, save=save, extension_params=extension_params, verbose=verbose, **kwargs)
+
+    def __repr__(self) -> str:
+        lines = [f"MultiFieldRoiAnalyzer: {len(self)} fields"]
+        for geom, analyzer in self.iter_fields():
+            extensions = ", ".join(analyzer.get_loaded_extension_names()) or "no extensions"
+            lines.append(
+                f"  [{geom.index}] {geom.name!r} uuid={geom.uuid} {analyzer.get_num_rois()} ROIs - {extensions}"
+            )
+        return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/src/photon_mosaic/core/tests/test_baseimaging.py
+++ b/src/photon_mosaic/core/tests/test_baseimaging.py
@@ -220,3 +220,28 @@ def test_generate_random_imaging_multiplane_has_expected_plane_dimension_and_sel
     sel = imaging.get_series(plane_ids=[1])
     assert sel.shape == (n, h, w, 1)
     np.all(sel[..., 0] == full[..., 1])
+
+
+def test_geometry_defaults_to_none():
+    imaging = generate_random_imaging(num_frames=5, height=6, width=7, sampling_frequency=10.0, seed=0)
+    assert imaging.geometry is None
+
+
+def test_geometry_set_and_get():
+    imaging = generate_random_imaging(num_frames=5, height=6, width=7, sampling_frequency=10.0, seed=0)
+    geometry = {"name": "field-A", "uuid": "UUID-A", "center_xy": (1.0, 2.0)}
+    imaging.geometry = geometry
+
+    assert imaging.geometry == geometry
+    # Placement shows up in the repr only when geometry is set.
+    assert "geometry" in repr(imaging)
+
+    imaging.geometry = None
+    assert imaging.geometry is None
+    assert "geometry" not in repr(imaging)
+
+
+def test_geometry_rejects_non_dict():
+    imaging = generate_random_imaging(num_frames=5, height=6, width=7, sampling_frequency=10.0, seed=0)
+    with pytest.raises(TypeError, match="geometry must be a dict or None"):
+        imaging.geometry = ["not", "a", "dict"]

--- a/src/photon_mosaic/core/tests/test_geometry.py
+++ b/src/photon_mosaic/core/tests/test_geometry.py
@@ -1,0 +1,86 @@
+"""Tests for the geometry_table helper over a collection of imaging fields."""
+
+import math
+
+from photon_mosaic.core import geometry_table
+from photon_mosaic.core.generators import generate_random_imaging
+
+
+def _is_null(value) -> bool:
+    """True for a missing placement value, whether None (list form) or NaN (pandas column)."""
+    return value is None or (isinstance(value, float) and math.isnan(value))
+
+
+def _make_field(height: int, width: int, sampling_frequency: float = 10.0, seed: int = 0):
+    """Create a small random single-plane imaging field."""
+    return generate_random_imaging(
+        num_frames=5, height=height, width=width, sampling_frequency=sampling_frequency, seed=seed
+    )
+
+
+def _rows(table):
+    """Normalise the table (DataFrame or list of dicts) to a list of row dicts."""
+    return table.to_dict("records") if hasattr(table, "to_dict") else table
+
+
+def test_geometry_table_reads_shape_from_fields():
+    fields = [_make_field(10, 10, seed=0), _make_field(12, 8, seed=1), _make_field(10, 10, seed=2)]
+    fields[0].geometry = {"name": "A", "uuid": "UUID-A", "center_xy": (0.0, 0.0), "size_xy": (1.0, 1.0)}
+    fields[1].geometry = {"name": "B", "uuid": "UUID-B", "center_xy": (2.0, 1.0), "size_xy": (1.0, 1.0)}
+    # fields[2] intentionally has no geometry.
+
+    rows = _rows(geometry_table(fields))
+
+    # Row index is the field's position; shape/frames/fs read from the field itself.
+    assert [row["index"] for row in rows] == [0, 1, 2]
+    assert (rows[1]["height"], rows[1]["width"]) == (12, 8)
+    assert rows[0]["num_frames"] == 5
+    assert rows[0]["num_planes"] == 1
+    assert rows[0]["sampling_frequency"] == 10.0
+    assert rows[0]["name"] == "A"
+    # A field without geometry gets null placement columns rather than an error.
+    assert rows[2]["name"] is None and _is_null(rows[2]["center_x"])
+
+
+def test_geometry_table_expected_columns():
+    rows = _rows(geometry_table([_make_field(10, 10)]))
+    expected_columns = {
+        "index",
+        "name",
+        "uuid",
+        "height",
+        "width",
+        "num_planes",
+        "num_frames",
+        "sampling_frequency",
+        "center_x",
+        "center_y",
+        "size_x",
+        "size_y",
+        "center_x_um",
+        "center_y_um",
+        "size_x_um",
+        "size_y_um",
+    }
+    assert expected_columns <= set(rows[0])
+
+
+def test_geometry_table_micron_columns():
+    field = _make_field(10, 10)
+    field.geometry = {"center_xy": (2.0, 3.0), "size_xy": (1.0, 1.0), "microns_per_scanner_unit": 150.0}
+
+    row = _rows(geometry_table([field]))[0]
+
+    assert (row["center_x_um"], row["center_y_um"]) == (2.0 * 150.0, 3.0 * 150.0)
+    assert (row["size_x_um"], row["size_y_um"]) == (150.0, 150.0)
+
+
+def test_geometry_table_micron_columns_none_without_scale():
+    field = _make_field(10, 10)
+    field.geometry = {"center_xy": (2.0, 3.0), "size_xy": (1.0, 1.0)}
+
+    row = _rows(geometry_table([field]))[0]
+
+    # Scanner-unit geometry present but no scale -> no micron view (not fabricated).
+    assert _is_null(row["center_x_um"]) and _is_null(row["size_x_um"])
+    assert (row["center_x"], row["center_y"]) == (2.0, 3.0)

--- a/src/photon_mosaic/core/tests/test_multifield.py
+++ b/src/photon_mosaic/core/tests/test_multifield.py
@@ -1,240 +1,67 @@
-"""Tests for the MultiFieldImaging container and FieldGeometry."""
+"""Tests for the multifield field-selection helpers (get_field, fields_containing_point)."""
 
-import numpy as np
 import pytest
 
-from photon_mosaic.core import (
-    BaseImaging,
-    FieldGeometry,
-    MultiFieldImaging,
-    generate_random_imaging,
-)
+from photon_mosaic.core import fields_containing_point, get_field
+from photon_mosaic.core.generators import generate_random_imaging
 
 
-def _make_field(height: int, width: int, sampling_frequency: float = 10.0, seed: int = 0) -> BaseImaging:
-    """Create a small random single-plane imaging field for testing."""
-    return generate_random_imaging(
-        num_frames=5,
-        height=height,
-        width=width,
-        sampling_frequency=sampling_frequency,
-        seed=seed,
-    )
+def _make_field(name=None, uuid=None, seed: int = 0):
+    """Create a small imaging field, optionally tagged with name/uuid in its geometry."""
+    imaging = generate_random_imaging(num_frames=5, height=10, width=10, sampling_frequency=10.0, seed=seed)
+    if name is not None or uuid is not None:
+        imaging.geometry = {"name": name, "uuid": uuid}
+    return imaging
 
 
 @pytest.fixture
-def multifield() -> MultiFieldImaging:
-    """A 3-field container with heterogeneous pixel shapes."""
-    fields = [_make_field(10, 10, seed=0), _make_field(12, 8, seed=1), _make_field(10, 10, seed=2)]
-    geometry = [
-        FieldGeometry(index=0, name="A", uuid="UUID-A", center_xy=(0.0, 0.0), size_xy=(1.0, 1.0), affine=np.eye(3)),
-        FieldGeometry(index=1, name="B", uuid="UUID-B", center_xy=(2.0, 1.0), size_xy=(1.0, 1.0)),
-        FieldGeometry(index=2, name="C", uuid="UUID-C"),
+def fields():
+    """Three fields with distinct names/uuids."""
+    return [
+        _make_field(name="A", uuid="UUID-A", seed=0),
+        _make_field(name="B", uuid="UUID-B", seed=1),
+        _make_field(name="C", uuid="UUID-C", seed=2),
     ]
-    return MultiFieldImaging(fields, geometry)
 
 
-def test_len_and_iteration(multifield):
-    assert len(multifield) == 3
-    assert all(isinstance(field, BaseImaging) for field in multifield)
+def test_get_field_by_index(fields):
+    assert get_field(fields, index=1) is fields[1]
 
 
-def test_getitem_int_and_slice(multifield):
-    assert multifield[0] is multifield.fields[0]
-    assert multifield[:2] == multifield.fields[:2]
+def test_get_field_by_name(fields):
+    assert get_field(fields, name="B") is fields[1]
 
 
-def test_iter_fields_pairs_are_aligned(multifield):
-    for geom, field in multifield.iter_fields():
-        assert isinstance(geom, FieldGeometry)
-        assert isinstance(field, BaseImaging)
-    assert [geom.index for geom, _ in multifield.iter_fields()] == [0, 1, 2]
+def test_get_field_by_uuid_is_case_insensitive(fields):
+    assert get_field(fields, uuid="uuid-b") is fields[1]
 
 
-def test_get_field_selects_by_index_name_and_uuid(multifield):
-    # Selector-resolution semantics (case-insensitivity, ambiguous/unknown/empty selectors) are
-    # covered upstream by roiextractors' _resolve_roi_index tests; here we only confirm the container
-    # hands back the field at the resolved position.
-    assert multifield.get_field(index=1) is multifield.fields[1]
-    assert multifield.get_field(name="B") is multifield.fields[1]
-    assert multifield.get_field(uuid="UUID-B") is multifield.fields[1]
+def test_get_field_requires_exactly_one_selector(fields):
+    with pytest.raises(ValueError, match="exactly one"):
+        get_field(fields)
+    with pytest.raises(ValueError, match="exactly one"):
+        get_field(fields, index=0, name="A")
 
 
-def test_geometry_table_reads_shape_from_fields(multifield):
-    table = multifield.geometry_table()
-    rows = table.to_dict("records") if hasattr(table, "to_dict") else table
-
-    # The middle field has a distinct pixel shape, read from the field itself.
-    assert (rows[1]["height"], rows[1]["width"]) == (12, 8)
-    assert rows[0]["num_frames"] == 5
-    assert rows[0]["num_planes"] == 1
-    assert rows[0]["sampling_frequency"] == 10.0
-    expected_columns = {
-        "index",
-        "name",
-        "uuid",
-        "height",
-        "width",
-        "num_planes",
-        "num_frames",
-        "sampling_frequency",
-        "center_x",
-        "center_y",
-        "size_x",
-        "size_y",
-    }
-    assert expected_columns <= set(rows[0])
+def test_get_field_unknown_name_raises(fields):
+    with pytest.raises(KeyError, match="no field matching"):
+        get_field(fields, name="Z")
 
 
-def test_geometry_table_includes_micron_columns():
-    field = _make_field(10, 10)
-    geom = FieldGeometry(index=0, center_xy=(2.0, 3.0), size_xy=(1.0, 1.0), microns_per_scanner_unit=150.0)
-    table = MultiFieldImaging([field], [geom]).geometry_table()
-    row = (table.to_dict("records") if hasattr(table, "to_dict") else table)[0]
-
-    assert {"center_x_um", "center_y_um", "size_x_um", "size_y_um"} <= set(row)
-    assert (row["center_x_um"], row["center_y_um"]) == (2.0 * 150.0, 3.0 * 150.0)
-    assert (row["size_x_um"], row["size_y_um"]) == (150.0, 150.0)
+def test_get_field_ambiguous_name_raises():
+    fields = [_make_field(name="dup", seed=0), _make_field(name="dup", seed=1)]
+    with pytest.raises(ValueError, match="ambiguous"):
+        get_field(fields, name="dup")
 
 
-def test_length_mismatch_raises():
-    with pytest.raises(ValueError, match="length mismatch"):
-        MultiFieldImaging([_make_field(10, 10)], [FieldGeometry(index=0), FieldGeometry(index=1)])
+def test_get_field_handles_fields_without_geometry():
+    # A field with no geometry simply never matches a name/uuid lookup.
+    fields = [_make_field(seed=0), _make_field(name="B", seed=1)]
+    assert get_field(fields, name="B") is fields[1]
+    with pytest.raises(KeyError):
+        get_field(fields, name="A")
 
 
-def test_non_baseimaging_field_raises():
-    with pytest.raises(TypeError, match="BaseImaging"):
-        MultiFieldImaging(["not imaging"], [FieldGeometry(index=0)])
-
-
-def test_heterogeneous_sampling_frequency_warns():
-    fields = [_make_field(10, 10, sampling_frequency=10.0), _make_field(10, 10, sampling_frequency=20.0)]
-    geometry = [FieldGeometry(index=0), FieldGeometry(index=1)]
-    with pytest.warns(UserWarning, match="heterogeneous sampling"):
-        MultiFieldImaging(fields, geometry)
-
-
-def test_field_geometry_defaults():
-    geom = FieldGeometry(index=3)
-    assert geom.name is None and geom.uuid is None
-    assert geom.center_xy is None and geom.size_xy is None and geom.affine is None
-    # Without a scale, the micron views are unavailable rather than fabricated.
-    assert geom.microns_per_scanner_unit is None
-    assert geom.center_xy_um is None and geom.size_xy_um is None
-
-
-def test_field_geometry_microns_conversion():
-    # microns_per_scanner_unit mirrors ScanImage's objectiveResolution; the *_um views scale by it.
-    geom = FieldGeometry(
-        index=0,
-        center_xy=(-6.9, -5.5),
-        size_xy=(4.6665, 4.6665),
-        microns_per_scanner_unit=150.0,
-    )
-    assert geom.center_xy_um == (-6.9 * 150.0, -5.5 * 150.0)
-    assert geom.size_xy_um == (4.6665 * 150.0, 4.6665 * 150.0)
-
-
-def test_field_geometry_microns_none_when_scale_missing():
-    # Scanner-unit geometry present but no scale -> no micron view.
-    geom = FieldGeometry(index=0, center_xy=(1.0, 2.0), size_xy=(3.0, 4.0))
-    assert geom.center_xy_um is None and geom.size_xy_um is None
-
-
-def test_field_geometry_microns_none_when_geometry_missing():
-    # Scale present but no scanner-unit geometry -> still no micron view.
-    geom = FieldGeometry(index=0, microns_per_scanner_unit=150.0)
-    assert geom.center_xy_um is None and geom.size_xy_um is None
-
-
-def _make_field_rois(num_rois: int, sampling_frequency: float = 10.0, seed: int = 0):
-    """Generate ROIs that fit a 20x20 field at the given sampling frequency."""
-    from photon_mosaic.core import generate_rois
-
-    return generate_rois(
-        num_rois=num_rois,
-        height=20,
-        width=20,
-        radius_range=(2, 5),
-        sampling_frequency=sampling_frequency,
-        seed=seed,
-    )
-
-
-def _make_multifield_roi_analyzer():
-    """Build a 2-field MultiFieldRoiAnalyzer with named/uuid'd fields for container tests."""
-    from photon_mosaic.core import create_multifield_roi_analyzer
-
-    fields = [_make_field(20, 20, seed=0), _make_field(20, 20, seed=1)]
-    geometry = [
-        FieldGeometry(index=0, name="A", uuid="UUID-A"),
-        FieldGeometry(index=1, name="B", uuid="UUID-B"),
-    ]
-    multifield = MultiFieldImaging(fields, geometry)
-    rois = [_make_field_rois(num_rois=3, seed=0), _make_field_rois(num_rois=2, seed=1)]
-    return create_multifield_roi_analyzer(rois, multifield)
-
-
-def test_create_multifield_roi_analyzer_returns_container():
-    from photon_mosaic.core import MultiFieldRoiAnalyzer, RoiAnalyzer
-
-    container = _make_multifield_roi_analyzer()
-
-    assert isinstance(container, MultiFieldRoiAnalyzer)
-    assert len(container) == 2
-    assert all(isinstance(analyzer, RoiAnalyzer) for analyzer in container)
-    # Each analyzer is paired with the matching field's ROIs, in order.
-    assert [analyzer.get_num_rois() for analyzer in container] == [3, 2]
-
-
-def test_container_getitem_and_iter_fields_are_aligned():
-    container = _make_multifield_roi_analyzer()
-
-    assert container[0] is container.analyzers[0]
-    assert container[:1] == container.analyzers[:1]
-    assert [geom.index for geom, _ in container.iter_fields()] == [0, 1]
-    for geom, analyzer in container.iter_fields():
-        assert isinstance(geom, FieldGeometry)
-        assert analyzer.get_num_rois() in (3, 2)
-
-
-def test_get_analyzer_selects_by_index_name_and_uuid():
-    # As with get_field, selector-resolution semantics live in roiextractors; this only checks the
-    # container returns the analyzer at the resolved position.
-    container = _make_multifield_roi_analyzer()
-
-    assert container.get_analyzer(index=1) is container[1]
-    assert container.get_analyzer(name="B") is container[1]
-    assert container.get_analyzer(uuid="UUID-B") is container[1]
-
-
-def test_compute_fans_out_to_every_field():
-    container = _make_multifield_roi_analyzer()
-
-    container.compute("fluorescence")
-
-    # Every field computed the extension independently, with its own ROI count on the ROI axis.
-    for analyzer, expected_num_rois in zip(container, (3, 2)):
-        fluorescence = analyzer.get_extension("fluorescence")
-        assert fluorescence is not None
-        assert fluorescence.get_data().shape == (5, expected_num_rois)
-
-
-def test_multifield_roi_analyzer_length_mismatch():
-    from photon_mosaic.core import MultiFieldRoiAnalyzer, RoiAnalyzer
-
-    container = _make_multifield_roi_analyzer()
-    analyzers: list[RoiAnalyzer] = list(container)
-
-    with pytest.raises(ValueError, match="length mismatch"):
-        MultiFieldRoiAnalyzer(analyzers, [FieldGeometry(index=0)])
-
-
-def test_create_multifield_roi_analyzer_length_mismatch():
-    from photon_mosaic.core import create_multifield_roi_analyzer
-
-    multifield = MultiFieldImaging([_make_field(20, 20)], [FieldGeometry(index=0)])
-    rois = [_make_field_rois(num_rois=2), _make_field_rois(num_rois=2)]
-
-    with pytest.raises(ValueError, match="must match"):
-        create_multifield_roi_analyzer(rois, multifield)
+def test_fields_containing_point_is_not_implemented(fields):
+    with pytest.raises(NotImplementedError, match="spatial field selection"):
+        fields_containing_point(fields, (0.0, 0.0))

--- a/src/photon_mosaic/core/tests/test_multifield.py
+++ b/src/photon_mosaic/core/tests/test_multifield.py
@@ -1,0 +1,240 @@
+"""Tests for the MultiFieldImaging container and FieldGeometry."""
+
+import numpy as np
+import pytest
+
+from photon_mosaic.core import (
+    BaseImaging,
+    FieldGeometry,
+    MultiFieldImaging,
+    generate_random_imaging,
+)
+
+
+def _make_field(height: int, width: int, sampling_frequency: float = 10.0, seed: int = 0) -> BaseImaging:
+    """Create a small random single-plane imaging field for testing."""
+    return generate_random_imaging(
+        num_frames=5,
+        height=height,
+        width=width,
+        sampling_frequency=sampling_frequency,
+        seed=seed,
+    )
+
+
+@pytest.fixture
+def multifield() -> MultiFieldImaging:
+    """A 3-field container with heterogeneous pixel shapes."""
+    fields = [_make_field(10, 10, seed=0), _make_field(12, 8, seed=1), _make_field(10, 10, seed=2)]
+    geometry = [
+        FieldGeometry(index=0, name="A", uuid="UUID-A", center_xy=(0.0, 0.0), size_xy=(1.0, 1.0), affine=np.eye(3)),
+        FieldGeometry(index=1, name="B", uuid="UUID-B", center_xy=(2.0, 1.0), size_xy=(1.0, 1.0)),
+        FieldGeometry(index=2, name="C", uuid="UUID-C"),
+    ]
+    return MultiFieldImaging(fields, geometry)
+
+
+def test_len_and_iteration(multifield):
+    assert len(multifield) == 3
+    assert all(isinstance(field, BaseImaging) for field in multifield)
+
+
+def test_getitem_int_and_slice(multifield):
+    assert multifield[0] is multifield.fields[0]
+    assert multifield[:2] == multifield.fields[:2]
+
+
+def test_iter_fields_pairs_are_aligned(multifield):
+    for geom, field in multifield.iter_fields():
+        assert isinstance(geom, FieldGeometry)
+        assert isinstance(field, BaseImaging)
+    assert [geom.index for geom, _ in multifield.iter_fields()] == [0, 1, 2]
+
+
+def test_get_field_selects_by_index_name_and_uuid(multifield):
+    # Selector-resolution semantics (case-insensitivity, ambiguous/unknown/empty selectors) are
+    # covered upstream by roiextractors' _resolve_roi_index tests; here we only confirm the container
+    # hands back the field at the resolved position.
+    assert multifield.get_field(index=1) is multifield.fields[1]
+    assert multifield.get_field(name="B") is multifield.fields[1]
+    assert multifield.get_field(uuid="UUID-B") is multifield.fields[1]
+
+
+def test_geometry_table_reads_shape_from_fields(multifield):
+    table = multifield.geometry_table()
+    rows = table.to_dict("records") if hasattr(table, "to_dict") else table
+
+    # The middle field has a distinct pixel shape, read from the field itself.
+    assert (rows[1]["height"], rows[1]["width"]) == (12, 8)
+    assert rows[0]["num_frames"] == 5
+    assert rows[0]["num_planes"] == 1
+    assert rows[0]["sampling_frequency"] == 10.0
+    expected_columns = {
+        "index",
+        "name",
+        "uuid",
+        "height",
+        "width",
+        "num_planes",
+        "num_frames",
+        "sampling_frequency",
+        "center_x",
+        "center_y",
+        "size_x",
+        "size_y",
+    }
+    assert expected_columns <= set(rows[0])
+
+
+def test_geometry_table_includes_micron_columns():
+    field = _make_field(10, 10)
+    geom = FieldGeometry(index=0, center_xy=(2.0, 3.0), size_xy=(1.0, 1.0), microns_per_scanner_unit=150.0)
+    table = MultiFieldImaging([field], [geom]).geometry_table()
+    row = (table.to_dict("records") if hasattr(table, "to_dict") else table)[0]
+
+    assert {"center_x_um", "center_y_um", "size_x_um", "size_y_um"} <= set(row)
+    assert (row["center_x_um"], row["center_y_um"]) == (2.0 * 150.0, 3.0 * 150.0)
+    assert (row["size_x_um"], row["size_y_um"]) == (150.0, 150.0)
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(ValueError, match="length mismatch"):
+        MultiFieldImaging([_make_field(10, 10)], [FieldGeometry(index=0), FieldGeometry(index=1)])
+
+
+def test_non_baseimaging_field_raises():
+    with pytest.raises(TypeError, match="BaseImaging"):
+        MultiFieldImaging(["not imaging"], [FieldGeometry(index=0)])
+
+
+def test_heterogeneous_sampling_frequency_warns():
+    fields = [_make_field(10, 10, sampling_frequency=10.0), _make_field(10, 10, sampling_frequency=20.0)]
+    geometry = [FieldGeometry(index=0), FieldGeometry(index=1)]
+    with pytest.warns(UserWarning, match="heterogeneous sampling"):
+        MultiFieldImaging(fields, geometry)
+
+
+def test_field_geometry_defaults():
+    geom = FieldGeometry(index=3)
+    assert geom.name is None and geom.uuid is None
+    assert geom.center_xy is None and geom.size_xy is None and geom.affine is None
+    # Without a scale, the micron views are unavailable rather than fabricated.
+    assert geom.microns_per_scanner_unit is None
+    assert geom.center_xy_um is None and geom.size_xy_um is None
+
+
+def test_field_geometry_microns_conversion():
+    # microns_per_scanner_unit mirrors ScanImage's objectiveResolution; the *_um views scale by it.
+    geom = FieldGeometry(
+        index=0,
+        center_xy=(-6.9, -5.5),
+        size_xy=(4.6665, 4.6665),
+        microns_per_scanner_unit=150.0,
+    )
+    assert geom.center_xy_um == (-6.9 * 150.0, -5.5 * 150.0)
+    assert geom.size_xy_um == (4.6665 * 150.0, 4.6665 * 150.0)
+
+
+def test_field_geometry_microns_none_when_scale_missing():
+    # Scanner-unit geometry present but no scale -> no micron view.
+    geom = FieldGeometry(index=0, center_xy=(1.0, 2.0), size_xy=(3.0, 4.0))
+    assert geom.center_xy_um is None and geom.size_xy_um is None
+
+
+def test_field_geometry_microns_none_when_geometry_missing():
+    # Scale present but no scanner-unit geometry -> still no micron view.
+    geom = FieldGeometry(index=0, microns_per_scanner_unit=150.0)
+    assert geom.center_xy_um is None and geom.size_xy_um is None
+
+
+def _make_field_rois(num_rois: int, sampling_frequency: float = 10.0, seed: int = 0):
+    """Generate ROIs that fit a 20x20 field at the given sampling frequency."""
+    from photon_mosaic.core import generate_rois
+
+    return generate_rois(
+        num_rois=num_rois,
+        height=20,
+        width=20,
+        radius_range=(2, 5),
+        sampling_frequency=sampling_frequency,
+        seed=seed,
+    )
+
+
+def _make_multifield_roi_analyzer():
+    """Build a 2-field MultiFieldRoiAnalyzer with named/uuid'd fields for container tests."""
+    from photon_mosaic.core import create_multifield_roi_analyzer
+
+    fields = [_make_field(20, 20, seed=0), _make_field(20, 20, seed=1)]
+    geometry = [
+        FieldGeometry(index=0, name="A", uuid="UUID-A"),
+        FieldGeometry(index=1, name="B", uuid="UUID-B"),
+    ]
+    multifield = MultiFieldImaging(fields, geometry)
+    rois = [_make_field_rois(num_rois=3, seed=0), _make_field_rois(num_rois=2, seed=1)]
+    return create_multifield_roi_analyzer(rois, multifield)
+
+
+def test_create_multifield_roi_analyzer_returns_container():
+    from photon_mosaic.core import MultiFieldRoiAnalyzer, RoiAnalyzer
+
+    container = _make_multifield_roi_analyzer()
+
+    assert isinstance(container, MultiFieldRoiAnalyzer)
+    assert len(container) == 2
+    assert all(isinstance(analyzer, RoiAnalyzer) for analyzer in container)
+    # Each analyzer is paired with the matching field's ROIs, in order.
+    assert [analyzer.get_num_rois() for analyzer in container] == [3, 2]
+
+
+def test_container_getitem_and_iter_fields_are_aligned():
+    container = _make_multifield_roi_analyzer()
+
+    assert container[0] is container.analyzers[0]
+    assert container[:1] == container.analyzers[:1]
+    assert [geom.index for geom, _ in container.iter_fields()] == [0, 1]
+    for geom, analyzer in container.iter_fields():
+        assert isinstance(geom, FieldGeometry)
+        assert analyzer.get_num_rois() in (3, 2)
+
+
+def test_get_analyzer_selects_by_index_name_and_uuid():
+    # As with get_field, selector-resolution semantics live in roiextractors; this only checks the
+    # container returns the analyzer at the resolved position.
+    container = _make_multifield_roi_analyzer()
+
+    assert container.get_analyzer(index=1) is container[1]
+    assert container.get_analyzer(name="B") is container[1]
+    assert container.get_analyzer(uuid="UUID-B") is container[1]
+
+
+def test_compute_fans_out_to_every_field():
+    container = _make_multifield_roi_analyzer()
+
+    container.compute("fluorescence")
+
+    # Every field computed the extension independently, with its own ROI count on the ROI axis.
+    for analyzer, expected_num_rois in zip(container, (3, 2)):
+        fluorescence = analyzer.get_extension("fluorescence")
+        assert fluorescence is not None
+        assert fluorescence.get_data().shape == (5, expected_num_rois)
+
+
+def test_multifield_roi_analyzer_length_mismatch():
+    from photon_mosaic.core import MultiFieldRoiAnalyzer, RoiAnalyzer
+
+    container = _make_multifield_roi_analyzer()
+    analyzers: list[RoiAnalyzer] = list(container)
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        MultiFieldRoiAnalyzer(analyzers, [FieldGeometry(index=0)])
+
+
+def test_create_multifield_roi_analyzer_length_mismatch():
+    from photon_mosaic.core import create_multifield_roi_analyzer
+
+    multifield = MultiFieldImaging([_make_field(20, 20)], [FieldGeometry(index=0)])
+    rois = [_make_field_rois(num_rois=2), _make_field_rois(num_rois=2)]
+
+    with pytest.raises(ValueError, match="must match"):
+        create_multifield_roi_analyzer(rois, multifield)

--- a/src/photon_mosaic/extractors/__init__.py
+++ b/src/photon_mosaic/extractors/__init__.py
@@ -35,3 +35,9 @@ def _setup_dynamic_imports():
 # Execute setup and clean up
 _setup_dynamic_imports()
 del _setup_dynamic_imports
+
+# Convenience builder for ScanImage multi-ROI files. Imported after the dynamic setup so the
+# generated loaders it relies on are already bound.
+from .scanimage_multifield import multifield_from_scanimage  # noqa: E402
+
+__all__.append("multifield_from_scanimage")

--- a/src/photon_mosaic/extractors/scanimage_multifield.py
+++ b/src/photon_mosaic/extractors/scanimage_multifield.py
@@ -7,6 +7,7 @@ extractor. When several files of one recording are passed, each field's imaging 
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Any, Literal
 
@@ -17,7 +18,6 @@ from roiextractors import ScanImageMultiROIImagingExtractor
 # package init; the generated loaders are resolved lazily at call time, once they exist.
 import photon_mosaic.extractors as pm_extractors
 from photon_mosaic.core import BaseImaging
-from photon_mosaic.core.multifield import FieldGeometry, MultiFieldImaging
 
 
 def _attach_field_timestamps(
@@ -73,8 +73,8 @@ def multifield_from_scanimage(
     file_paths: list[str | Path] | None = None,
     timestamps: Literal["per_frame", "per_field"] = "per_frame",
     frame_timestamps: str | Path | np.ndarray | None = None,
-) -> MultiFieldImaging:
-    """Build a :class:`MultiFieldImaging` from one or more ScanImage multi-ROI TIFFs.
+) -> list[BaseImaging]:
+    """Build a list of imaging fields from one or more ScanImage multi-ROI TIFFs.
 
     A ScanImage recording is often split across several files. Passing them all ties their samples
     together, so each field's :class:`BaseImaging` spans the whole recording in time.
@@ -102,9 +102,9 @@ def multifield_from_scanimage(
 
     Returns
     -------
-    MultiFieldImaging
-        One :class:`BaseImaging` per scan field (each spanning all input files) plus the
-        lateral-placement geometry table.
+    list[BaseImaging]
+        One :class:`BaseImaging` per scan field (each spanning all input files), with its lateral
+        placement stored in the field's ``geometry`` dict (see :attr:`BaseImaging.geometry`).
     """
     if timestamps not in ("per_frame", "per_field"):
         raise ValueError(f"timestamps must be 'per_frame' or 'per_field', got {timestamps!r}")
@@ -141,7 +141,6 @@ def multifield_from_scanimage(
     num_fields = ScanImageMultiROIImagingExtractor.get_num_rois(first_file)
 
     fields: list[BaseImaging] = []
-    geometry: list[FieldGeometry] = []
     for field_index in range(num_fields):
         # Each field is wrapped as a standalone BaseImaging via the dynamic loader; passing the
         # file(s) makes the field span the full recording across files.
@@ -150,19 +149,17 @@ def multifield_from_scanimage(
         extractor = imaging.epochs[0].roiextractor_extractor
         affine = np.asarray(extractor.roi_affine, dtype=float) if extractor.roi_affine is not None else None
         # Microns per scanner-angle unit: ScanImage's objective resolution, read from the frame
-        # metadata. Lets FieldGeometry expose the geometry in micrometers as well as scanner units.
+        # metadata. Lets downstream code express the geometry in micrometers as well as scanner units.
         objective_resolution = extractor._metadata.get("SI.objectiveResolution")
         microns_per_scanner_unit = float(objective_resolution) if objective_resolution is not None else None
-        geometry.append(
-            FieldGeometry(
-                index=field_index,
-                name=extractor.roi_name,
-                uuid=extractor.roi_uuid,
-                center_xy=tuple(extractor.roi_center_xy) if extractor.roi_center_xy is not None else None,
-                size_xy=tuple(extractor.roi_size_xy) if extractor.roi_size_xy is not None else None,
-                affine=affine,
-                microns_per_scanner_unit=microns_per_scanner_unit,
-            )
+        # Lateral placement and identity, stored directly on the field (see BaseImaging.geometry).
+        imaging.geometry = dict(
+            name=extractor.roi_name,
+            uuid=extractor.roi_uuid,
+            center_xy=tuple(extractor.roi_center_xy) if extractor.roi_center_xy is not None else None,
+            size_xy=tuple(extractor.roi_size_xy) if extractor.roi_size_xy is not None else None,
+            affine=affine,
+            microns_per_scanner_unit=microns_per_scanner_unit,
         )
         # Attach per-plane physical depth (z) when the extractor exposes it. ScanImage stores the
         # ROI's z-plane(s) as ``zs`` -- a scalar for a planar field, one value per plane for a
@@ -177,4 +174,12 @@ def multifield_from_scanimage(
         _attach_field_timestamps(imaging, extractor, timestamps, full_frame_timestamps)
         fields.append(imaging)
 
-    return MultiFieldImaging(fields=fields, geometry=geometry)
+    # Fields are expected to be co-acquired (one shared timebase); flag a mixed set rather than fail.
+    sampling_frequencies = {round(field.sampling_frequency, 4) for field in fields}
+    if len(sampling_frequencies) > 1:
+        warnings.warn(
+            f"fields have heterogeneous sampling frequencies: {sorted(sampling_frequencies)}",
+            UserWarning,
+        )
+
+    return fields

--- a/src/photon_mosaic/extractors/scanimage_multifield.py
+++ b/src/photon_mosaic/extractors/scanimage_multifield.py
@@ -1,0 +1,180 @@
+"""Build a :class:`MultiFieldImaging` from one or more ScanImage multi-ROI (mesoscope) TIFFs.
+
+Each scan field is loaded as a standalone :class:`BaseImaging` through photon-mosaic's dynamically
+generated ScanImage loader, and its lateral placement is read off the underlying roiextractors
+extractor. When several files of one recording are passed, each field's imaging spans them all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+from roiextractors import ScanImageMultiROIImagingExtractor
+
+# Bind the extractors package (not its dynamic attributes) so this module can be imported during
+# package init; the generated loaders are resolved lazily at call time, once they exist.
+import photon_mosaic.extractors as pm_extractors
+from photon_mosaic.core import BaseImaging
+from photon_mosaic.core.multifield import FieldGeometry, MultiFieldImaging
+
+
+def _attach_field_timestamps(
+    imaging: BaseImaging,
+    extractor: Any,
+    timestamps: str,
+    full_frame_timestamps: np.ndarray | None,
+) -> None:
+    """Mirror a field's acquisition timestamps from the extractor onto its imaging object.
+
+    The extractor resolves the base per-frame timeline -- a custom override set here via
+    ``set_times``, else the file's native ``frameTimestamps_sec``, else nominal
+    ``arange(num_frames) / sampling_frequency`` -- and, in ``"per_field"`` mode, adds the field's
+    within-frame scan offset (``get_field_time_offset()``: ScanImage's per-row dwell time times the
+    field's start row, modelling that fields are scanned sequentially top to bottom). This copies the
+    resolved vector onto the :class:`BaseImaging` time vector, which photon-mosaic reads
+    independently of the extractor.
+
+    Parameters
+    ----------
+    imaging : BaseImaging
+        The field to annotate (single epoch).
+    extractor : Any
+        The underlying roiextractors ``ScanImageMultiROIImagingExtractor``.
+    timestamps : str
+        ``"per_frame"`` (frame timestamps as-is) or ``"per_field"`` (add the within-frame offset).
+    full_frame_timestamps : np.ndarray | None
+        Optional custom per-frame base timeline shared by all fields, or None to use the extractor's
+        own timestamps.
+    """
+    num_frames = extractor.get_num_samples()
+
+    # A custom base timeline (shared across fields) overrides the extractor's native timestamps; the
+    # per-field offset is applied on read below, not baked into the stored base.
+    if full_frame_timestamps is not None:
+        if full_frame_timestamps.size < num_frames:
+            raise ValueError(
+                f"frame_timestamps has {full_frame_timestamps.size} entries but the field has "
+                f"{num_frames} frames; need at least as many"
+            )
+        extractor.set_times(np.asarray(full_frame_timestamps[:num_frames], dtype=float))
+
+    # The extractor resolves the base timeline and adds the per-field offset when requested (raising
+    # if "per_field" is asked for but the offset can't be computed); mirror the result onto the
+    # imaging object's own (independent) time vector.
+    correct_field_offset = timestamps == "per_field"
+    field_times = extractor.get_timestamps(correct_field_offset=correct_field_offset)
+    imaging.set_times(np.asarray(field_times, dtype=float), segment_index=0, with_warning=False)
+
+
+def multifield_from_scanimage(
+    file_path: str | Path | None = None,
+    file_paths: list[str | Path] | None = None,
+    timestamps: Literal["per_frame", "per_field"] = "per_frame",
+    frame_timestamps: str | Path | np.ndarray | None = None,
+) -> MultiFieldImaging:
+    """Build a :class:`MultiFieldImaging` from one or more ScanImage multi-ROI TIFFs.
+
+    A ScanImage recording is often split across several files. Passing them all ties their samples
+    together, so each field's :class:`BaseImaging` spans the whole recording in time.
+
+    Parameters
+    ----------
+    file_path : str | Path | None
+        Path to a single ScanImage TIFF. If the file is part of a multi-file series, this should be
+        the first file and the remaining files are detected automatically. Mutually exclusive with
+        ``file_paths``.
+    file_paths : list[str | Path] | None
+        Explicit list of files in temporal order, overriding automatic detection. Use this when the
+        files cannot be auto-detected or you want exact control over their order.
+    timestamps : "per_frame" | "per_field", default: "per_frame"
+        How to time-stamp the fields. ``"per_frame"`` treats each frame as acquired in a single
+        instant, so all fields share the same per-frame timeline. ``"per_field"`` adds a per-field
+        offset modelling sequential scanning within a frame: ``offset = line_period * roi_row_start``
+        (ScanImage's per-row dwell time, from metadata, times the field's start row).
+    frame_timestamps : str | Path | np.ndarray | None, default: None
+        Optional custom per-frame timestamps, treated as full-frame timestamps shared by all fields
+        (then offset per field when ``timestamps="per_field"``). May be an array or a path to a
+        ``.npy`` file; it is flattened and cropped to the frames read. If None, each field uses the
+        extractor's native per-frame timestamps (the file's ``frameTimestamps_sec``), falling back to
+        the sampling frequency when those are unavailable.
+
+    Returns
+    -------
+    MultiFieldImaging
+        One :class:`BaseImaging` per scan field (each spanning all input files) plus the
+        lateral-placement geometry table.
+    """
+    if timestamps not in ("per_frame", "per_field"):
+        raise ValueError(f"timestamps must be 'per_frame' or 'per_field', got {timestamps!r}")
+    if file_path is None and file_paths is None:
+        raise ValueError("provide either file_path or file_paths")
+    if file_paths is not None and len(file_paths) == 0:
+        raise ValueError("file_paths must not be empty")
+
+    # Load custom full-frame timestamps once (shared across all fields), if given.
+    full_frame_timestamps: np.ndarray | None = None
+    if frame_timestamps is not None:
+        if isinstance(frame_timestamps, (str, Path)):
+            frame_timestamps = np.load(Path(frame_timestamps).expanduser())
+        full_frame_timestamps = np.asarray(frame_timestamps, dtype=float).ravel()
+
+    # read_scan_image_multi_roi_imaging is generated dynamically at import time (see
+    # extractors/roiextractors.py), so it is invisible to static analysis; resolve it at call time.
+    read_field = pm_extractors.read_scan_image_multi_roi_imaging  # type: ignore[attr-defined]
+
+    # The loader forwards these straight to the underlying extractor, which concatenates the files.
+    # file_paths (explicit order) takes precedence over file_path (single / series head).
+    loader_kwargs: dict[str, Any]
+    if file_paths is not None:
+        loader_kwargs = {"file_paths": [Path(path) for path in file_paths]}
+        first_file = Path(file_paths[0])
+    else:
+        assert file_path is not None  # guaranteed by the validation above
+        loader_kwargs = {"file_path": Path(file_path)}
+        first_file = Path(file_path)
+
+    # Cheap metadata read: how many fields are stacked. The ROI layout is identical across files in
+    # a series, so the first file suffices. get_num_rois is a static method on the underlying
+    # roiextractors extractor, not on the photon-mosaic wrapper.
+    num_fields = ScanImageMultiROIImagingExtractor.get_num_rois(first_file)
+
+    fields: list[BaseImaging] = []
+    geometry: list[FieldGeometry] = []
+    for field_index in range(num_fields):
+        # Each field is wrapped as a standalone BaseImaging via the dynamic loader; passing the
+        # file(s) makes the field span the full recording across files.
+        imaging = read_field(roi_index=field_index, **loader_kwargs)
+        # Reach through the wrapper to the underlying extractor for the physical geometry.
+        extractor = imaging.epochs[0].roiextractor_extractor
+        affine = np.asarray(extractor.roi_affine, dtype=float) if extractor.roi_affine is not None else None
+        # Microns per scanner-angle unit: ScanImage's objective resolution, read from the frame
+        # metadata. Lets FieldGeometry expose the geometry in micrometers as well as scanner units.
+        objective_resolution = extractor._metadata.get("SI.objectiveResolution")
+        microns_per_scanner_unit = float(objective_resolution) if objective_resolution is not None else None
+        geometry.append(
+            FieldGeometry(
+                index=field_index,
+                name=extractor.roi_name,
+                uuid=extractor.roi_uuid,
+                center_xy=tuple(extractor.roi_center_xy) if extractor.roi_center_xy is not None else None,
+                size_xy=tuple(extractor.roi_size_xy) if extractor.roi_size_xy is not None else None,
+                affine=affine,
+                microns_per_scanner_unit=microns_per_scanner_unit,
+            )
+        )
+        # Attach per-plane physical depth (z) when the extractor exposes it. ScanImage stores the
+        # ROI's z-plane(s) as ``zs`` -- a scalar for a planar field, one value per plane for a
+        # (future) volumetric z-stack. Depth belongs on the field's own plane axis, so it is set as
+        # a per-plane property; skip if the count does not match the field's planes (no fabrication).
+        roi_zs = getattr(extractor, "roi_zs", None)
+        if roi_zs is not None:
+            plane_depths = np.atleast_1d(np.asarray(roi_zs, dtype=float))
+            if plane_depths.size == imaging.num_planes:
+                imaging.set_property("z", plane_depths)
+        # Attach the time vector (shared per-frame, optionally offset per field).
+        _attach_field_timestamps(imaging, extractor, timestamps, full_frame_timestamps)
+        fields.append(imaging)
+
+    return MultiFieldImaging(fields=fields, geometry=geometry)

--- a/src/photon_mosaic/extractors/scanimage_multifield.py
+++ b/src/photon_mosaic/extractors/scanimage_multifield.py
@@ -147,7 +147,9 @@ def multifield_from_scanimage(
         imaging = read_field(roi_index=field_index, **loader_kwargs)
         # Reach through the wrapper to the underlying extractor for the physical geometry.
         extractor = imaging.epochs[0].roiextractor_extractor
-        affine = np.asarray(extractor.roi_affine, dtype=float) if extractor.roi_affine is not None else None
+        # The geometry dict is stored as a JSON-serializable annotation (see BaseImaging.geometry), so
+        # the affine is a 3x3 list of lists rather than an ndarray; wrap in np.asarray at use.
+        affine = np.asarray(extractor.roi_affine, dtype=float).tolist() if extractor.roi_affine is not None else None
         # Microns per scanner-angle unit: ScanImage's objective resolution, read from the frame
         # metadata. Lets downstream code express the geometry in micrometers as well as scanner units.
         objective_resolution = extractor._metadata.get("SI.objectiveResolution")
@@ -156,8 +158,8 @@ def multifield_from_scanimage(
         imaging.geometry = dict(
             name=extractor.roi_name,
             uuid=extractor.roi_uuid,
-            center_xy=tuple(extractor.roi_center_xy) if extractor.roi_center_xy is not None else None,
-            size_xy=tuple(extractor.roi_size_xy) if extractor.roi_size_xy is not None else None,
+            center_xy=list(extractor.roi_center_xy) if extractor.roi_center_xy is not None else None,
+            size_xy=list(extractor.roi_size_xy) if extractor.roi_size_xy is not None else None,
             affine=affine,
             microns_per_scanner_unit=microns_per_scanner_unit,
         )

--- a/src/photon_mosaic/extractors/tests/test_scanimage_multifield.py
+++ b/src/photon_mosaic/extractors/tests/test_scanimage_multifield.py
@@ -1,0 +1,25 @@
+"""Tests for the multifield_from_scanimage builder.
+
+Only the argument validation is exercised here, since it runs before any file access and therefore
+needs no ScanImage fixture. The file-reading path is covered by the local demo against real data.
+"""
+
+import pytest
+
+from photon_mosaic.extractors import multifield_from_scanimage
+
+
+def test_requires_a_file_argument():
+    with pytest.raises(ValueError, match="provide either"):
+        multifield_from_scanimage()
+
+
+def test_rejects_empty_file_paths():
+    with pytest.raises(ValueError, match="must not be empty"):
+        multifield_from_scanimage(file_paths=[])
+
+
+def test_rejects_invalid_timestamps_mode():
+    # Validated before any file access, so no fixture is needed.
+    with pytest.raises(ValueError, match="per_frame"):
+        multifield_from_scanimage(file_path="dummy.tif", timestamps="nope")


### PR DESCRIPTION
> **Draft / work-in-progress.** This is a checkpoint to share direction and get
> early feedback. Public APIs, names, and on-disk layout are provisional and
> will change. Not ready to merge.

> **⚠️ Requires the ScanImage multi-ROI support from `roiextractors` PR
> [catalystneuro/roiextractors#597](https://github.com/catalystneuro/roiextractors/pull/597).**
> `ScanImageMultiROIImagingExtractor` and the per-ROI geometry/timing this PR reads
> off it are introduced there and are not on any `roiextractors` release yet. You
> must install it before this code will import or run, e.g.:
>
> ```bash
> pip install "roiextractors @ git+https://github.com/catalystneuro/roiextractors.git@refs/pull/597/head"
> ```
>
> (or an editable local checkout of that branch). This is a hard build/runtime
> requirement, not just for the tests.

## Motivation

Mesoscope / ScanImage multi-ROI acquisitions capture several **independent
fields of view** in one recording — each with its own pixel grid and physical
position in the sample. These cannot be honestly stacked into a single
`BaseImaging` (they share neither a pixel grid nor a regular depth axis).

This PR introduces a **bag-of-fields** model: each field stays its own
`BaseImaging`, and lightweight container classes add cohesion (shared identity,
selection, geometry) on top.

## Scope: planar first, volumetric-ready

The current goal is **planar** multi-field data. The design is deliberately
shaped so that extending to **volumetric** fields (per-field multi-plane
z-stacks) later is a natural next step rather than a redesign, by keeping two
levels of multiplicity separate:

- **within a field** — the `planes` axis of one `BaseImaging` (where a future
  z-stack would live);
- **across fields** — this container (free pixel shape, free lateral position).

Accordingly, `FieldGeometry` carries the field's **lateral** placement and
identity (`center_xy`, `size_xy`, `affine`, `name`, `uuid`) in scanner-angle
units, with an optional `microns_per_scanner_unit` scale powering derived `*_um`
views; depth is left to a field's own plane axis. Full volumetric mROI is **not**
implemented yet and will first need support in `roiextractors`; this PR just lays
the foundation on the photon-mosaic side.

## What's in here

### `core/multifield.py` — `MultiFieldImaging` + `FieldGeometry`

A container holding one independent `BaseImaging` per field alongside a parallel
`FieldGeometry` table. It offers `len`/iteration/indexing, `iter_fields()` →
`(geometry, imaging)`, selection by `index`/`name`/`uuid`, a `geometry_table()`
(pandas if available), and basic validation (field type, length match, a warning
on heterogeneous sampling frequency).

### `extractors/scanimage_multifield.py` — `multifield_from_scanimage()`

A factory that builds a `MultiFieldImaging` from one or more ScanImage multi-ROI
TIFFs. Each scan field is loaded as a standalone `BaseImaging` through
photon-mosaic's dynamically generated ScanImage loader; its geometry (name,
uuid, center/size, affine, microns-per-scanner-unit from `SI.objectiveResolution`)
is read off the underlying `roiextractors` extractor (requires PR
[catalystneuro/roiextractors#597](https://github.com/catalystneuro/roiextractors/pull/597)
— see the requirement note above). Passing all files of a multi-file recording
ties their samples together so each field spans the whole recording.

**Temporal handling** (`_attach_field_timestamps`): the extractor resolves a
base per-frame timeline (a custom override, else the file's native
`frameTimestamps_sec`, else nominal `arange / fs`) and this is mirrored onto each
field's own independent time vector. Two modes:

- `"per_frame"` (default) — every field shares the same per-frame timeline.
- `"per_field"` — adds the within-frame scan offset
  (`line_period × roi_row_start`), modelling that fields are scanned
  sequentially top-to-bottom within a frame.

An optional custom full-frame timestamp array (or `.npy` path) can override the
native timeline and is shared across fields (then offset per field in
`"per_field"` mode).

### `core/roianalyzer.py` — `MultiFieldRoiAnalyzer` *(design up for discussion)*

The analyzer-side glue class, mirroring `MultiFieldImaging`. It pairs one
**independent** `RoiAnalyzer` per field with the geometry table and re-exposes
the same cohesion surface (`len`/iter/indexing, `iter_fields()`,
`get_analyzer(index|name|uuid)`). Its `compute()` is a thin **fan-out** that
delegates to each field's `RoiAnalyzer.compute()` — results stay on their own
field's analyzer. `create_multifield_roi_analyzer()` now returns this container
instead of a bare list. Field-selection logic is factored into a shared
`_resolve_field_selector` helper used by both containers.

**This piece is the most open part of the PR and is explicitly up for
discussion** — whether a dedicated container is the right abstraction at all, how
per-field analyzers should be grouped, and how cross-field results should
eventually be combined (see below). Feedback very welcome here.

## Tests

Unit tests cover the container mechanics, geometry table, validation, and the
`compute()` fan-out, plus the ScanImage factory. Selector-resolution **semantics**
(case-insensitivity, ambiguity, unknown/empty selectors) are intentionally **not**
re-tested here — they're owned and tested upstream in `roiextractors`; we only
verify photon-mosaic's wiring on top.

## Deliberately deferred (not in this PR)

- **Cross-field combination** of extension outputs — `compute()` is fan-out only.
  Sketch: an on-demand `get_combined_extension_data(name)` on the container + a
  `combine_field_data` hook on `AnalyzerExtension` (combine policy lives on the
  extension), with results keyed by a `(field, roi_id)` MultiIndex. Part of the
  "up for discussion" above.
- **Save/load round-trip** for `MultiFieldRoiAnalyzer` — no `loading.py` dispatch
  branch yet; per-field analyzers are written to `field_<i>/` subfolders that are
  individually loadable via `load_roi_analyzer`.
- **Volumetric mROI** — planar-only for now; needs `roiextractors` support first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
