### PR TITLE
Add stack_planes and split_epoch_at_frames core primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# macOS
+.DS_Store

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -14,5 +14,10 @@ from .roianalyzer import (
     register_result_extension,
 )
 from .roianalyzer_core_extensions import FluorescenceExtension
-from .split import SelectEpochImaging, split_epochs
+from .split import (
+    SelectEpochImaging,
+    SplitEpochAtFramesImaging,
+    split_epoch_at_frames,
+    split_epochs,
+)
 from .zarrrois import ZarrRois

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -20,4 +20,5 @@ from .split import (
     split_epoch_at_frames,
     split_epochs,
 )
+from .stack import StackPlanesImaging, stack_planes
 from .zarrrois import ZarrRois

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -1,4 +1,8 @@
-from .baseimaging import BaseImaging
+from typing import Sequence
+
+import numpy as np
+
+from .baseimaging import BaseImaging, BaseImagingEpoch
 
 
 def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) -> list[int]:
@@ -46,3 +50,84 @@ class SelectEpochImaging(BaseImaging):
 def split_epochs(imaging: BaseImaging, epoch_indices: int | list[int]) -> SelectEpochImaging:
     """Return a proxy imaging object with only the requested epochs."""
     return SelectEpochImaging(imaging=imaging, epoch_indices=epoch_indices)
+
+
+class _FrameRangeEpoch(BaseImagingEpoch):
+    """Lazy view over a contiguous frame range of a parent epoch."""
+
+    def __init__(self, parent_epoch: BaseImagingEpoch, start_frame: int, end_frame: int):
+        t_start = parent_epoch.t_start if getattr(parent_epoch, "t_start", None) is not None else 0.0
+        sampling_frequency = parent_epoch.sampling_frequency
+        BaseImagingEpoch.__init__(  # type: ignore[call-arg]
+            self,
+            sampling_frequency=sampling_frequency,
+            t_start=t_start + start_frame / sampling_frequency,
+        )
+        self._parent_epoch = parent_epoch
+        self._start = int(start_frame)
+        self._end = int(end_frame)
+
+    def get_num_samples(self) -> int:
+        return self._end - self._start
+
+    def get_series(self, start_frame, end_frame, plane_indices=None):
+        return self._parent_epoch.get_series(
+            self._start + start_frame,
+            self._start + end_frame,
+            plane_indices,
+        )
+
+
+class SplitEpochAtFramesImaging(BaseImaging):
+    """Imaging proxy that subdivides one epoch of a parent into several sub-epochs.
+
+    The frame boundaries are interpreted in the same way as ``np.split``: the
+    boundaries split the parent epoch into ``len(boundaries) + 1`` contiguous
+    pieces, each exposed as its own epoch on the returned object. Pixels are
+    pulled lazily from the parent — no data is copied.
+    """
+
+    def __init__(self, imaging: BaseImaging, epoch_index: int, frame_boundaries: Sequence[int]):
+        num_epochs = imaging.get_num_epochs()
+        if not isinstance(epoch_index, int) or isinstance(epoch_index, bool):
+            raise TypeError("epoch_index must be an int")
+        if not 0 <= epoch_index < num_epochs:
+            raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")
+
+        parent_epoch = imaging.epochs[epoch_index]
+        n_samples = parent_epoch.get_num_samples()
+
+        boundaries = list(map(int, frame_boundaries))
+        if any(b <= 0 or b >= n_samples for b in boundaries):
+            raise ValueError(f"frame_boundaries must be strictly between 0 and {n_samples}; got {boundaries}")
+        if any(boundaries[i] >= boundaries[i + 1] for i in range(len(boundaries) - 1)):
+            raise ValueError(f"frame_boundaries must be strictly increasing; got {boundaries}")
+
+        BaseImaging.__init__(self, sampling_frequency=imaging.sampling_frequency, shape=imaging.shape)
+        imaging.copy_metadata(self)
+
+        edges = [0, *boundaries, n_samples]
+        for lo, hi in zip(edges[:-1], edges[1:]):
+            self.add_epoch(_FrameRangeEpoch(parent_epoch, lo, hi))
+
+        self._parent = imaging
+        self._kwargs = {
+            "imaging": imaging,
+            "epoch_index": epoch_index,
+            "frame_boundaries": np.asarray(boundaries, dtype=int).tolist(),
+        }
+
+
+def split_epoch_at_frames(
+    imaging: BaseImaging,
+    epoch_index: int,
+    frame_boundaries: Sequence[int],
+) -> SplitEpochAtFramesImaging:
+    """Split one epoch of ``imaging`` into contiguous sub-epochs at the given frame boundaries.
+
+    Convenience wrapper for :class:`SplitEpochAtFramesImaging`. Useful when an
+    extractor exposes recorded files as a single concatenated epoch (e.g.
+    suite2p's per-plane ``data.bin`` plus ``ops['frames_per_file']``) and you
+    want each underlying file as its own epoch.
+    """
+    return SplitEpochAtFramesImaging(imaging=imaging, epoch_index=epoch_index, frame_boundaries=frame_boundaries)

--- a/src/photon_mosaic/core/stack.py
+++ b/src/photon_mosaic/core/stack.py
@@ -1,0 +1,199 @@
+"""Stack imaging objects along the plane axis.
+
+Several imaging objects covering the same field of view at the same timestamps
+(each providing one or more planes) are joined into a single multi-plane volume
+without copying the underlying pixels — planes are pulled lazily from the parent
+objects on read, and only from the parents that actually hold the requested
+planes. A general core primitive; see the suite2p extractor for one caller.
+"""
+
+from typing import Sequence
+
+import numpy as np
+
+from .baseimaging import BaseImaging, BaseImagingEpoch
+
+
+class _StackedPlanesEpoch(BaseImagingEpoch):
+    """Lazy epoch whose planes are gathered from several parent epochs.
+
+    Each parent epoch contributes a contiguous block of planes; on read the
+    blocks are joined along the plane axis into
+    ``(num_samples, H, W, sum_of_planes)``. Only the parents holding requested
+    planes are read.
+    """
+
+    def __init__(
+        self,
+        parent_epochs: Sequence[BaseImagingEpoch],
+        height: int,
+        width: int,
+        planes_per_parent: Sequence[int],
+        dtype: np.dtype,
+    ):
+        first = parent_epochs[0]
+        BaseImagingEpoch.__init__(  # type: ignore[call-arg]
+            self,
+            sampling_frequency=first.sampling_frequency,
+            t_start=getattr(first, "t_start", None),
+        )
+        self._parent_epochs = list(parent_epochs)
+        self._height = int(height)
+        self._width = int(width)
+        self._dtype = np.dtype(dtype)
+        self._planes_per_parent = [int(n) for n in planes_per_parent]
+        self._num_planes = int(sum(self._planes_per_parent))
+        # Global index of each parent's first plane, so a requested global plane
+        # index resolves to (parent, local index) without reading anything.
+        self._parent_offsets = np.cumsum([0, *self._planes_per_parent[:-1]]).tolist()
+
+    def get_num_samples(self) -> int:
+        return self._parent_epochs[0].get_num_samples()
+
+    def get_series(
+        self,
+        start_frame: int,
+        end_frame: int,
+        plane_indices: slice | np.ndarray | None = None,
+    ) -> np.ndarray:
+        requested = self._resolve_plane_indices(plane_indices)
+        if not requested:
+            return np.empty((end_frame - start_frame, self._height, self._width, 0), dtype=self._dtype)
+
+        # Group the requested planes by the parent holding them, so each parent
+        # is read at most once and parents holding none are not read at all.
+        local_by_parent: dict[int, list[int]] = {}
+        for global_index in requested:
+            parent = int(np.searchsorted(self._parent_offsets, global_index, side="right") - 1)
+            local_by_parent.setdefault(parent, []).append(global_index - self._parent_offsets[parent])
+
+        by_parent = sorted(local_by_parent.items())
+        parts = [
+            self._parent_epochs[parent].get_series(start_frame, end_frame, self._parent_selection(parent, local))
+            for parent, local in by_parent
+        ]
+        stacked = np.concatenate(parts, axis=-1) if len(parts) > 1 else parts[0]
+
+        # ``stacked`` is in parent order; restore the order the caller asked for.
+        gathered = [self._parent_offsets[parent] + local for parent, locals_ in by_parent for local in locals_]
+        if gathered == requested:
+            return stacked
+        position = {global_index: i for i, global_index in enumerate(gathered)}
+        return stacked[..., [position[global_index] for global_index in requested]]
+
+    def _parent_selection(self, parent: int, local: list[int]) -> slice | np.ndarray:
+        """Pick how to ask ``parent`` for ``local``.
+
+        A parent asked for all of its planes in order gets a slice, so it can
+        hand back a view instead of an advanced-indexing copy — the whole-volume
+        read is the common case and should stay as cheap as it was.
+        """
+        if local == list(range(self._planes_per_parent[parent])):
+            return slice(None)
+        return np.asarray(local, dtype=int)
+
+    def _resolve_plane_indices(self, plane_indices: slice | np.ndarray | None) -> list[int]:
+        """Normalise ``plane_indices`` to an explicit list of global plane indices.
+
+        Negative indices count from the last plane, as they do on the sibling
+        epochs that index a numpy array directly.
+        """
+        if plane_indices is None:
+            return list(range(self._num_planes))
+        if isinstance(plane_indices, slice):
+            return list(range(*plane_indices.indices(self._num_planes)))
+        candidates = np.atleast_1d(plane_indices)
+        if candidates.dtype == bool:
+            # A boolean mask selects planes, it does not name them by index.
+            candidates = np.flatnonzero(candidates)
+        indices = []
+        for raw in candidates:
+            index = int(raw)
+            if index < 0:
+                index += self._num_planes
+            if not 0 <= index < self._num_planes:
+                raise IndexError(f"Plane index {int(raw)} out of range for {self._num_planes} planes")
+            indices.append(index)
+        return indices
+
+
+class StackPlanesImaging(BaseImaging):
+    """Imaging proxy that stacks several imaging objects along the plane axis.
+
+    All inputs must share the same epoch structure (number of epochs and the
+    per-epoch frame counts), the same ``(height, width)``, sampling frequency
+    and dtype. The resulting object has ``sum(num_planes)`` planes and pulls
+    pixels lazily from the inputs — no data is copied.
+
+    Parameters
+    ----------
+    imagings : sequence of BaseImaging
+        Two or more imaging objects covering the same field of view at the
+        same timestamps, each providing one or more planes.
+    """
+
+    def __init__(self, imagings: Sequence[BaseImaging]):
+        imagings = list(imagings)
+        if len(imagings) < 2:
+            raise ValueError("stack_planes requires at least two imaging objects")
+        for i, im in enumerate(imagings):
+            if not isinstance(im, BaseImaging):
+                raise TypeError(f"Input {i} is not a BaseImaging (got {type(im).__name__})")
+
+        ref = imagings[0]
+        num_epochs = ref.get_num_epochs()
+        height, width = int(ref.shape[0]), int(ref.shape[1])
+        fs = ref.sampling_frequency
+        dtype = ref.get_dtype()
+        ref_samples = [ref.epochs[e].get_num_samples() for e in range(num_epochs)]
+
+        for i, im in enumerate(imagings[1:], start=1):
+            if im.get_num_epochs() != num_epochs:
+                raise ValueError(f"Input {i} has {im.get_num_epochs()} epochs but input 0 has {num_epochs}")
+            if (int(im.shape[0]), int(im.shape[1])) != (height, width):
+                raise ValueError(
+                    f"Input {i} has frame shape ({im.shape[0]}, {im.shape[1]}) " f"but input 0 has ({height}, {width})"
+                )
+            if im.sampling_frequency != fs:
+                raise ValueError(f"Input {i} sampling frequency {im.sampling_frequency} disagrees with input 0 ({fs})")
+            if np.dtype(im.get_dtype()) != np.dtype(dtype):
+                raise ValueError(f"Input {i} dtype {im.get_dtype()} disagrees with input 0 ({dtype})")
+            samples = [im.epochs[e].get_num_samples() for e in range(num_epochs)]
+            if samples != ref_samples:
+                raise ValueError(f"Input {i} per-epoch frame counts {samples} disagree with input 0 ({ref_samples})")
+
+        planes_per_parent = [int(im.num_planes) for im in imagings]
+        total_planes = sum(planes_per_parent)
+        BaseImaging.__init__(self, sampling_frequency=fs, shape=(height, width, total_planes))
+
+        for epoch_index in range(num_epochs):
+            parent_epochs = [im.epochs[epoch_index] for im in imagings]
+            self.add_epoch(_StackedPlanesEpoch(parent_epochs, height, width, planes_per_parent, dtype))
+
+        self._parents = imagings
+        self._kwargs = {"imagings": imagings}
+        self.name = f"Stacked planes ({total_planes} planes from {len(imagings)} objects)"
+
+
+def stack_planes(*imagings: BaseImaging) -> StackPlanesImaging:
+    """Stack imaging objects along the plane axis into one multi-plane volume.
+
+    Accepts the objects either as separate arguments (``stack_planes(a, b)``)
+    or as a single sequence (``stack_planes([a, b])``).
+
+    Parameters
+    ----------
+    *imagings : BaseImaging
+        Two or more imaging objects of the same FOV / timestamps; see
+        :class:`StackPlanesImaging`.
+
+    Returns
+    -------
+    StackPlanesImaging
+        A lazy multi-plane view over the inputs.
+    """
+    if len(imagings) == 1 and isinstance(imagings[0], (list, tuple)):
+        items: Sequence[BaseImaging] = imagings[0]
+    else:
+        items = imagings
+    return StackPlanesImaging(items)

--- a/src/photon_mosaic/core/tests/test_split.py
+++ b/src/photon_mosaic/core/tests/test_split.py
@@ -2,7 +2,12 @@ import numpy as np
 import pytest
 
 from photon_mosaic.core.generators import generate_random_imaging
-from photon_mosaic.core.split import SelectEpochImaging, split_epochs
+from photon_mosaic.core.split import (
+    SelectEpochImaging,
+    SplitEpochAtFramesImaging,
+    split_epoch_at_frames,
+    split_epochs,
+)
 
 
 def test_split_epoch_with_single_index_returns_single_epoch_proxy():
@@ -45,3 +50,32 @@ def test_split_epoch_raises_on_invalid_indices():
 
     with pytest.raises(TypeError):
         _ = split_epochs(imaging, [0, False])
+
+
+def test_split_epoch_at_frames_produces_contiguous_sub_epochs():
+    imaging = generate_random_imaging(num_frames=(20,), height=4, width=5, sampling_frequency=10.0, seed=3)
+    full = imaging.get_series(epoch_index=0)
+
+    sub = split_epoch_at_frames(imaging, 0, [7, 13])
+
+    assert isinstance(sub, SplitEpochAtFramesImaging)
+    assert sub.get_num_epochs() == 3
+    assert [sub.get_num_samples(segment_index=i) for i in range(3)] == [7, 6, 7]
+    np.testing.assert_array_equal(sub.get_series(epoch_index=0), full[:7])
+    np.testing.assert_array_equal(sub.get_series(epoch_index=1), full[7:13])
+    np.testing.assert_array_equal(sub.get_series(epoch_index=2), full[13:])
+
+
+def test_split_epoch_at_frames_validates_boundaries():
+    imaging = generate_random_imaging(num_frames=(10,), height=3, width=3, sampling_frequency=10.0, seed=4)
+
+    with pytest.raises(IndexError):
+        _ = split_epoch_at_frames(imaging, 1, [3])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [0])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [10])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [5, 5])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [5, 3])

--- a/src/photon_mosaic/core/tests/test_stack.py
+++ b/src/photon_mosaic/core/tests/test_stack.py
@@ -1,0 +1,218 @@
+import numpy as np
+import pytest
+
+from photon_mosaic.core.generators import generate_random_imaging
+from photon_mosaic.core.stack import StackPlanesImaging, stack_planes
+
+
+def _imaging(num_frames, planes, seed):
+    return generate_random_imaging(
+        num_frames=num_frames, height=5, width=6, sampling_frequency=20.0, num_planes=planes, seed=seed
+    )
+
+
+def test_stack_two_single_plane_objects():
+    a = _imaging(8, 1, seed=0)
+    b = _imaging(8, 1, seed=1)
+
+    joined = stack_planes(a, b)
+
+    assert isinstance(joined, StackPlanesImaging)
+    assert joined.get_num_planes() == 2
+    assert tuple(joined.shape) == (5, 6, 2)
+
+    out = joined.get_series()
+    assert out.shape == (8, 5, 6, 2)
+    np.testing.assert_array_equal(out[..., 0], a.get_series()[..., 0])
+    np.testing.assert_array_equal(out[..., 1], b.get_series()[..., 0])
+
+
+def test_stack_multi_plane_objects_and_plane_selection():
+    a = _imaging(7, 2, seed=2)
+    b = _imaging(7, 3, seed=3)
+
+    joined = stack_planes(a, b)
+    assert joined.get_num_planes() == 5
+
+    full = joined.get_series()
+    assert full.shape == (7, 5, 6, 5)
+    np.testing.assert_array_equal(full[..., 0:2], a.get_series())
+    np.testing.assert_array_equal(full[..., 2:5], b.get_series())
+
+    # plane selection crossing the boundary between the two inputs
+    sel = joined.get_series(plane_ids=[1, 3])
+    assert sel.shape == (7, 5, 6, 2)
+    np.testing.assert_array_equal(sel[..., 0], a.get_series()[..., 1])
+    np.testing.assert_array_equal(sel[..., 1], b.get_series()[..., 1])
+
+
+def test_stack_preserves_requested_plane_order():
+    """An out-of-order request must come back in the requested order.
+
+    Planes are gathered parent by parent, so without an explicit reorder a
+    request for [3, 0] would silently return [0, 3].
+    """
+    a = _imaging(6, 2, seed=20)
+    b = _imaging(6, 2, seed=21)
+
+    joined = stack_planes(a, b)
+
+    out = joined.get_series(plane_ids=[3, 0])
+    assert out.shape == (6, 5, 6, 2)
+    np.testing.assert_array_equal(out[..., 0], b.get_series()[..., 1])
+    np.testing.assert_array_equal(out[..., 1], a.get_series()[..., 0])
+
+    # within a single parent, too
+    within = joined.get_series(plane_ids=[1, 0])
+    np.testing.assert_array_equal(within[..., 0], a.get_series()[..., 1])
+    np.testing.assert_array_equal(within[..., 1], a.get_series()[..., 0])
+
+
+def test_stack_does_not_read_parents_without_requested_planes():
+    """Planes are pulled only from the parents that hold them.
+
+    Guards the push-down: a naive implementation reads every parent in full and
+    slices afterwards, which costs one full read per plane of the volume.
+    """
+    a = _imaging(6, 1, seed=22)
+    b = _imaging(6, 1, seed=23)
+    c = _imaging(6, 1, seed=24)
+
+    joined = stack_planes(a, b, c)
+
+    calls = []
+    for index, epoch in enumerate(joined.epochs[0]._parent_epochs):
+        original = epoch.get_series
+
+        def spy(start, end, plane_indices=None, _i=index, _f=original):
+            calls.append(_i)
+            return _f(start, end, plane_indices)
+
+        epoch.get_series = spy
+
+    out = joined.get_series(plane_ids=[1])
+
+    assert calls == [1]
+    np.testing.assert_array_equal(out[..., 0], b.get_series()[..., 0])
+
+
+def test_stack_empty_plane_selection_returns_empty_plane_axis():
+    a = _imaging(6, 1, seed=27)
+    b = _imaging(6, 1, seed=28)
+    joined = stack_planes(a, b)
+
+    out = joined.get_series(plane_ids=[])
+    assert out.shape == (6, 5, 6, 0)
+    assert out.dtype == a.get_dtype()
+
+
+def test_stack_accepts_negative_plane_indices():
+    """Negative indices count from the end, as they do on the sibling epochs."""
+    a = _imaging(6, 2, seed=29)
+    b = _imaging(6, 1, seed=30)
+    joined = stack_planes(a, b)
+
+    last = joined.epochs[0].get_series(0, 6, np.array([-1]))
+    np.testing.assert_array_equal(last[..., 0], b.get_series()[..., 0])
+
+    mixed = joined.epochs[0].get_series(0, 6, np.array([-1, 0]))
+    np.testing.assert_array_equal(mixed[..., 0], b.get_series()[..., 0])
+    np.testing.assert_array_equal(mixed[..., 1], a.get_series()[..., 0])
+
+
+def test_stack_treats_a_boolean_mask_as_a_mask():
+    """A boolean array selects planes; it does not name them by index."""
+    a = _imaging(6, 2, seed=33)
+    b = _imaging(6, 2, seed=34)
+    joined = stack_planes(a, b)
+
+    out = joined.epochs[0].get_series(0, 6, np.array([True, False, True, False]))
+    assert out.shape == (6, 5, 6, 2)
+    np.testing.assert_array_equal(out[..., 0], a.get_series()[..., 0])
+    np.testing.assert_array_equal(out[..., 1], b.get_series()[..., 0])
+
+
+def test_stack_reads_whole_parents_by_slice_not_index_array():
+    """A parent giving up all its planes is asked with a slice.
+
+    An index array would force an advanced-indexing copy, making the common
+    whole-volume read more expensive than it needs to be.
+    """
+    a = _imaging(6, 2, seed=31)
+    b = _imaging(6, 2, seed=32)
+    joined = stack_planes(a, b)
+
+    seen = []
+    for epoch in joined.epochs[0]._parent_epochs:
+        original = epoch.get_series
+
+        def spy(start, end, plane_indices=None, _f=original):
+            seen.append(plane_indices)
+            return _f(start, end, plane_indices)
+
+        epoch.get_series = spy
+
+    _ = joined.get_series()
+
+    assert all(isinstance(s, slice) for s in seen), seen
+
+
+def test_stack_rejects_out_of_range_plane_index():
+    a = _imaging(5, 1, seed=25)
+    b = _imaging(5, 1, seed=26)
+    joined = stack_planes(a, b)
+
+    with pytest.raises(IndexError):
+        _ = joined.epochs[0].get_series(0, 5, np.array([2]))
+
+    with pytest.raises(IndexError):
+        _ = joined.epochs[0].get_series(0, 5, np.array([-3]))
+
+
+def test_stack_multi_epoch():
+    a = _imaging((4, 6), 1, seed=4)
+    b = _imaging((4, 6), 2, seed=5)
+
+    joined = stack_planes(a, b)
+    assert joined.get_num_epochs() == 2
+    assert joined.get_num_planes() == 3
+
+    out1 = joined.get_series(epoch_index=1)
+    assert out1.shape == (6, 5, 6, 3)
+    np.testing.assert_array_equal(out1[..., 0:1], a.get_series(epoch_index=1))
+    np.testing.assert_array_equal(out1[..., 1:3], b.get_series(epoch_index=1))
+
+
+def test_stack_accepts_single_sequence():
+    a = _imaging(5, 1, seed=6)
+    b = _imaging(5, 1, seed=7)
+    joined = stack_planes([a, b])
+    assert joined.get_num_planes() == 2
+
+
+def test_stack_rejects_mismatched_inputs():
+    a = _imaging(8, 1, seed=10)
+
+    with pytest.raises(ValueError, match="at least two"):
+        _ = stack_planes(a)
+
+    # mismatched frame counts
+    b_short = _imaging(7, 1, seed=11)
+    with pytest.raises(ValueError, match="frame counts"):
+        _ = stack_planes(a, b_short)
+
+    # mismatched number of epochs
+    b_epochs = _imaging((8, 3), 1, seed=12)
+    with pytest.raises(ValueError, match="epochs"):
+        _ = stack_planes(a, b_epochs)
+
+    # mismatched frame shape
+    b_shape = generate_random_imaging(num_frames=8, height=9, width=6, sampling_frequency=20.0, num_planes=1, seed=13)
+    with pytest.raises(ValueError, match="frame shape"):
+        _ = stack_planes(a, b_shape)
+
+
+def test_stack_rejects_non_imaging_input():
+    a = _imaging(5, 1, seed=14)
+    with pytest.raises(TypeError):
+        _ = stack_planes(a, "not an imaging")


### PR DESCRIPTION
First of two PRs splitting #83. This half is the generic `core` primitives, with no suite2p knowledge; the extractor that uses them follows in the stacked PR.

**`stack_planes`** — joins imaging objects sharing a field of view and timestamps into one multi-plane volume, lazily. Planes are pulled only from the parents that hold the requested ones, so a single plane of an N-plane volume costs one parent read rather than N (@alejoe91's review point on #83). A parent giving up all of its planes is asked with a slice, so the whole-volume read still gets views rather than advanced-indexing copies. Results are reordered to the requested order, since gathering parent by parent would otherwise return `[3, 0]` as `[0, 3]`.

Named `stack_planes` rather than `concatenate_planes` per @alejoe91: `concatenate_*` means concatenation in time, here and in SpikeInterface.

**`split_epoch_at_frames`** — subdivides one epoch of a parent into contiguous sub-epochs at the given frame boundaries, `np.split` style. Useful when an extractor exposes several recorded files as a single concatenated epoch and you want each file back as its own epoch.

Both are lazy proxies — no pixels are copied.

Tests cover plane selection across parent boundaries, requested-plane ordering, that non-contributing parents are not read at all, empty and negative selections, boolean masks, and multi-epoch. Each new test was checked to fail against the implementation it guards.