### PR TITLE
Add Suite2pImaging extractor for registered binary movies (#77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# macOS
+.DS_Store

--- a/examples/suite2p_extractor.ipynb
+++ b/examples/suite2p_extractor.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "s2p-intro",
+   "metadata": {},
+   "source": [
+    "# Loading suite2p output: movies and ROIs\n",
+    "\n",
+    "This notebook shows how to load a **pre-computed suite2p run** — the registered\n",
+    "binary movies suite2p writes to disk, and the ROIs detected from them — into\n",
+    "`photon-mosaic`, following the three use cases from\n",
+    "[issue #77](https://github.com/photon-mosaic/photon-mosaic/issues/77):\n",
+    "\n",
+    "1. **Per-plane load + stitch** — each plane is a `Suite2pImaging`; combine them with `stack_planes`. Each plane's ROIs (`read_suite2p_rois`) pair 1:1 with its movie via `register_imaging`.\n",
+    "2. **Whole folder** — `read_suite2p_full` loads every plane, stitches them, and marks the movie as registered (one object per functional channel).\n",
+    "3. **Per-file epochs** — `Suite2pImaging.into_epochs()` recovers one epoch per source acquisition file from `ops['frames_per_file']`.\n",
+    "\n",
+    "Point `SUITE2P_FOLDER` below at your own suite2p output root: the parent of\n",
+    "`plane0/`, `plane1/`, … , each containing `data.bin` and `ops.npy`.\n",
+    "\n",
+    "> **Multi-plane ROIs.** ROIs pair with the movie **per plane** (use case 1)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s2p-setup-md",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Edit the path to point at your suite2p output folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "s2p-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from photon_mosaic.core import stack_planes\n",
+    "from photon_mosaic.extractors.suite2pbin import read_suite2p_binary, read_suite2p_full\n",
+    "from photon_mosaic.extractors.suite2prois import read_suite2p_rois\n",
+    "from photon_mosaic.widgets.series import plot_imaging_series\n",
+    "\n",
+    "# EDIT ME: a suite2p output root (the parent of plane0/, plane1/, ...)\n",
+    "SUITE2P_FOLDER = Path(\"path/to/suite2p/output/root\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s2p-uc1-md",
+   "metadata": {},
+   "source": [
+    "## Use case 1 — load each plane, then stitch\n",
+    "\n",
+    "Each plane directory is loaded with `read_suite2p_binary` (the alias for\n",
+    "`Suite2pImaging`) as its own single-plane object. Because a single plane maps to one\n",
+    "binary on disk, these objects stay binary-compatible. `stack_planes` then\n",
+    "stacks them into one `(T, H, W, n_planes)` volume — a lazy view that pulls pixels\n",
+    "from each plane's memmap on read, without copying.\n",
+    "\n",
+    "The plane's **ROIs** live in the *same* directory: `read_suite2p_rois` loads that\n",
+    "plane's `stat.npy`. Because both are single-plane, they pair 1:1 —\n",
+    "`rois.register_imaging(plane)` attaches the movie to its ROIs (the plane counts must\n",
+    "match, which is exactly what makes one imaging object map to one ROI object)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "s2p-uc1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plane0 shape: (512, 512, 1) | registered: True\n",
+      "stitched volume shape: (512, 512, 2)\n",
+      "plane0 ROIs: 355 | paired imaging: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "plane0 = read_suite2p_binary(SUITE2P_FOLDER / \"plane0\")\n",
+    "plane1 = read_suite2p_binary(SUITE2P_FOLDER / \"plane1\")\n",
+    "print(\"plane0 shape:\", plane0.shape, \"| registered:\", plane0.is_registered)\n",
+    "\n",
+    "volume = stack_planes(plane0, plane1)\n",
+    "print(\"stitched volume shape:\", volume.shape)\n",
+    "\n",
+    "# One plane's ROIs, paired 1:1 with that plane's movie.\n",
+    "plane0_rois = read_suite2p_rois(SUITE2P_FOLDER / \"plane0\")\n",
+    "plane0_rois.register_imaging(plane0)\n",
+    "print(\"plane0 ROIs:\", plane0_rois.get_num_rois(), \"| paired imaging:\", plane0_rois.has_imaging())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s2p-uc2-md",
+   "metadata": {},
+   "source": [
+    "## Use case 2 — load a whole folder with `read_suite2p_full`\n",
+    "\n",
+    "`read_suite2p_full` finds every `plane*/` under the folder, loads each as a\n",
+    "`Suite2pImaging`, and stitches them for you. It returns a single object for a\n",
+    "one-channel run (a `(chan1, chan2)` tuple when the run has two functional\n",
+    "channels), with `is_registered=True`.\n",
+    "\n",
+    "As for now, ROIs are not loaded automatically, because they are per-plane."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "s2p-uc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imaging = read_suite2p_full(SUITE2P_FOLDER)\n",
+    "if isinstance(imaging, tuple):  # two functional channels\n",
+    "    imaging, imaging_chan2 = imaging\n",
+    "\n",
+    "print(\"shape        :\", imaging.shape)\n",
+    "print(\"num planes   :\", imaging.num_planes)\n",
+    "print(\"sampling rate:\", imaging.sampling_frequency, \"Hz\")\n",
+    "print(\"is_registered:\", imaging.is_registered)\n",
+    "\n",
+    "plot_imaging_series(imaging, backend=\"ipywidgets\", colormap=\"plasma\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "s2p-uc3-md",
+   "metadata": {},
+   "source": [
+    "## Use case 3 — split into one epoch per source file\n",
+    "\n",
+    "suite2p concatenates the source acquisition files into one registered movie and\n",
+    "records the per-file frame counts in `ops['frames_per_file']`. `photon-mosaic`\n",
+    "keeps those counts on the imaging object, so `Suite2pImaging.into_epochs()` turns\n",
+    "the single long movie back into one epoch per original file — lazily, without\n",
+    "re-reading any pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "s2p-uc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "source files (epochs): 2\n",
+      "frames per file      : [2000, 10000]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# into_epochs() is a method on a single-plane Suite2pImaging (see plane0 above).\n",
+    "per_file = plane0.into_epochs()\n",
+    "print(\"source files (epochs):\", per_file.get_num_epochs())\n",
+    "sizes = [per_file.get_num_samples(segment_index=i) for i in range(per_file.get_num_epochs())]\n",
+    "print(\"frames per file      :\", sizes)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "photon-mosaic (3.13.1)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -14,5 +14,10 @@ from .roianalyzer import (
     register_result_extension,
 )
 from .roianalyzer_core_extensions import FluorescenceExtension
-from .split import SelectEpochImaging, split_epochs
+from .split import (
+    SelectEpochImaging,
+    SplitEpochAtFramesImaging,
+    split_epoch_at_frames,
+    split_epochs,
+)
 from .zarrrois import ZarrRois

--- a/src/photon_mosaic/core/__init__.py
+++ b/src/photon_mosaic/core/__init__.py
@@ -20,4 +20,5 @@ from .split import (
     split_epoch_at_frames,
     split_epochs,
 )
+from .stack import StackPlanesImaging, stack_planes
 from .zarrrois import ZarrRois

--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -19,7 +19,12 @@ class BaseImaging(BaseExtractor, TimeSeries):
     The `_main_ids` attribute is used here for multi-plane imaging objects.
     """
 
-    def __init__(self, sampling_frequency: float, shape: tuple | list | ArrayLike):
+    def __init__(
+        self,
+        sampling_frequency: float,
+        shape: tuple | list | ArrayLike,
+        is_registered: bool = False,
+    ):
         # Should we allow users to provide 2D shape (H, W) for single plane imaging?
         if len(shape) == 2:
             shape = (shape[0], shape[1], 1)
@@ -29,6 +34,9 @@ class BaseImaging(BaseExtractor, TimeSeries):
         self._sampling_frequency = float(sampling_frequency)
         self._shape = tuple(shape)  # Image is intended as a volume (H, W, planes)
         self._average_image = None
+        # Stored as an annotation so that copy_metadata propagates it to proxy/preprocessor
+        # views (epoch selection, splitting, plane concatenation) without extra wiring.
+        self.set_annotation("is_registered", bool(is_registered), overwrite=True)
 
     def _repr_header(self, display_name=True):
         """Generate text representation of the BaseImaging object."""
@@ -120,6 +128,25 @@ class BaseImaging(BaseExtractor, TimeSeries):
             The shape of the images as (height, width).
         """
         return self._shape
+
+    @property
+    def is_registered(self) -> bool:
+        """Whether this imaging holds motion-corrected (registered) data.
+
+        ``False`` by default. Set to ``True`` when the movie is loaded from a
+        suite2p output (already registered) or produced by photon-mosaic's own
+        registration. Propagated to proxy/preprocessor views via copy_metadata.
+
+        Returns
+        -------
+        bool
+            True if the underlying movie is registered.
+        """
+        return bool(self._annotations.get("is_registered", False))
+
+    @is_registered.setter
+    def is_registered(self, value: bool) -> None:
+        self.set_annotation("is_registered", bool(value), overwrite=True)
 
     @property
     def plane_ids(self):

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -1,4 +1,8 @@
-from .baseimaging import BaseImaging
+from typing import Sequence
+
+import numpy as np
+
+from .baseimaging import BaseImaging, BaseImagingEpoch
 
 
 def _normalize_epoch_indices(epoch_indices: int | list[int], num_epochs: int) -> list[int]:
@@ -46,3 +50,84 @@ class SelectEpochImaging(BaseImaging):
 def split_epochs(imaging: BaseImaging, epoch_indices: int | list[int]) -> SelectEpochImaging:
     """Return a proxy imaging object with only the requested epochs."""
     return SelectEpochImaging(imaging=imaging, epoch_indices=epoch_indices)
+
+
+class _FrameRangeEpoch(BaseImagingEpoch):
+    """Lazy view over a contiguous frame range of a parent epoch."""
+
+    def __init__(self, parent_epoch: BaseImagingEpoch, start_frame: int, end_frame: int):
+        t_start = parent_epoch.t_start if getattr(parent_epoch, "t_start", None) is not None else 0.0
+        sampling_frequency = parent_epoch.sampling_frequency
+        BaseImagingEpoch.__init__(  # type: ignore[call-arg]
+            self,
+            sampling_frequency=sampling_frequency,
+            t_start=t_start + start_frame / sampling_frequency,
+        )
+        self._parent_epoch = parent_epoch
+        self._start = int(start_frame)
+        self._end = int(end_frame)
+
+    def get_num_samples(self) -> int:
+        return self._end - self._start
+
+    def get_series(self, start_frame, end_frame, plane_indices=None):
+        return self._parent_epoch.get_series(
+            self._start + start_frame,
+            self._start + end_frame,
+            plane_indices,
+        )
+
+
+class SplitEpochAtFramesImaging(BaseImaging):
+    """Imaging proxy that subdivides one epoch of a parent into several sub-epochs.
+
+    The frame boundaries are interpreted in the same way as ``np.split``: the
+    boundaries split the parent epoch into ``len(boundaries) + 1`` contiguous
+    pieces, each exposed as its own epoch on the returned object. Pixels are
+    pulled lazily from the parent — no data is copied.
+    """
+
+    def __init__(self, imaging: BaseImaging, epoch_index: int, frame_boundaries: Sequence[int]):
+        num_epochs = imaging.get_num_epochs()
+        if not isinstance(epoch_index, int) or isinstance(epoch_index, bool):
+            raise TypeError("epoch_index must be an int")
+        if not 0 <= epoch_index < num_epochs:
+            raise IndexError(f"Epoch index {epoch_index} out of range for imaging with {num_epochs} epochs")
+
+        parent_epoch = imaging.epochs[epoch_index]
+        n_samples = parent_epoch.get_num_samples()
+
+        boundaries = list(map(int, frame_boundaries))
+        if any(b <= 0 or b >= n_samples for b in boundaries):
+            raise ValueError(f"frame_boundaries must be strictly between 0 and {n_samples}; got {boundaries}")
+        if any(boundaries[i] >= boundaries[i + 1] for i in range(len(boundaries) - 1)):
+            raise ValueError(f"frame_boundaries must be strictly increasing; got {boundaries}")
+
+        BaseImaging.__init__(self, sampling_frequency=imaging.sampling_frequency, shape=imaging.shape)
+        imaging.copy_metadata(self)
+
+        edges = [0, *boundaries, n_samples]
+        for lo, hi in zip(edges[:-1], edges[1:]):
+            self.add_epoch(_FrameRangeEpoch(parent_epoch, lo, hi))
+
+        self._parent = imaging
+        self._kwargs = {
+            "imaging": imaging,
+            "epoch_index": epoch_index,
+            "frame_boundaries": np.asarray(boundaries, dtype=int).tolist(),
+        }
+
+
+def split_epoch_at_frames(
+    imaging: BaseImaging,
+    epoch_index: int,
+    frame_boundaries: Sequence[int],
+) -> SplitEpochAtFramesImaging:
+    """Split one epoch of ``imaging`` into contiguous sub-epochs at the given frame boundaries.
+
+    Convenience wrapper for :class:`SplitEpochAtFramesImaging`. Useful when an
+    extractor exposes recorded files as a single concatenated epoch (e.g.
+    suite2p's per-plane ``data.bin`` plus ``ops['frames_per_file']``) and you
+    want each underlying file as its own epoch.
+    """
+    return SplitEpochAtFramesImaging(imaging=imaging, epoch_index=epoch_index, frame_boundaries=frame_boundaries)

--- a/src/photon_mosaic/core/stack.py
+++ b/src/photon_mosaic/core/stack.py
@@ -1,0 +1,199 @@
+"""Stack imaging objects along the plane axis.
+
+Several imaging objects covering the same field of view at the same timestamps
+(each providing one or more planes) are joined into a single multi-plane volume
+without copying the underlying pixels — planes are pulled lazily from the parent
+objects on read, and only from the parents that actually hold the requested
+planes. A general core primitive; see the suite2p extractor for one caller.
+"""
+
+from typing import Sequence
+
+import numpy as np
+
+from .baseimaging import BaseImaging, BaseImagingEpoch
+
+
+class _StackedPlanesEpoch(BaseImagingEpoch):
+    """Lazy epoch whose planes are gathered from several parent epochs.
+
+    Each parent epoch contributes a contiguous block of planes; on read the
+    blocks are joined along the plane axis into
+    ``(num_samples, H, W, sum_of_planes)``. Only the parents holding requested
+    planes are read.
+    """
+
+    def __init__(
+        self,
+        parent_epochs: Sequence[BaseImagingEpoch],
+        height: int,
+        width: int,
+        planes_per_parent: Sequence[int],
+        dtype: np.dtype,
+    ):
+        first = parent_epochs[0]
+        BaseImagingEpoch.__init__(  # type: ignore[call-arg]
+            self,
+            sampling_frequency=first.sampling_frequency,
+            t_start=getattr(first, "t_start", None),
+        )
+        self._parent_epochs = list(parent_epochs)
+        self._height = int(height)
+        self._width = int(width)
+        self._dtype = np.dtype(dtype)
+        self._planes_per_parent = [int(n) for n in planes_per_parent]
+        self._num_planes = int(sum(self._planes_per_parent))
+        # Global index of each parent's first plane, so a requested global plane
+        # index resolves to (parent, local index) without reading anything.
+        self._parent_offsets = np.cumsum([0, *self._planes_per_parent[:-1]]).tolist()
+
+    def get_num_samples(self) -> int:
+        return self._parent_epochs[0].get_num_samples()
+
+    def get_series(
+        self,
+        start_frame: int,
+        end_frame: int,
+        plane_indices: slice | np.ndarray | None = None,
+    ) -> np.ndarray:
+        requested = self._resolve_plane_indices(plane_indices)
+        if not requested:
+            return np.empty((end_frame - start_frame, self._height, self._width, 0), dtype=self._dtype)
+
+        # Group the requested planes by the parent holding them, so each parent
+        # is read at most once and parents holding none are not read at all.
+        local_by_parent: dict[int, list[int]] = {}
+        for global_index in requested:
+            parent = int(np.searchsorted(self._parent_offsets, global_index, side="right") - 1)
+            local_by_parent.setdefault(parent, []).append(global_index - self._parent_offsets[parent])
+
+        by_parent = sorted(local_by_parent.items())
+        parts = [
+            self._parent_epochs[parent].get_series(start_frame, end_frame, self._parent_selection(parent, local))
+            for parent, local in by_parent
+        ]
+        stacked = np.concatenate(parts, axis=-1) if len(parts) > 1 else parts[0]
+
+        # ``stacked`` is in parent order; restore the order the caller asked for.
+        gathered = [self._parent_offsets[parent] + local for parent, locals_ in by_parent for local in locals_]
+        if gathered == requested:
+            return stacked
+        position = {global_index: i for i, global_index in enumerate(gathered)}
+        return stacked[..., [position[global_index] for global_index in requested]]
+
+    def _parent_selection(self, parent: int, local: list[int]) -> slice | np.ndarray:
+        """Pick how to ask ``parent`` for ``local``.
+
+        A parent asked for all of its planes in order gets a slice, so it can
+        hand back a view instead of an advanced-indexing copy — the whole-volume
+        read is the common case and should stay as cheap as it was.
+        """
+        if local == list(range(self._planes_per_parent[parent])):
+            return slice(None)
+        return np.asarray(local, dtype=int)
+
+    def _resolve_plane_indices(self, plane_indices: slice | np.ndarray | None) -> list[int]:
+        """Normalise ``plane_indices`` to an explicit list of global plane indices.
+
+        Negative indices count from the last plane, as they do on the sibling
+        epochs that index a numpy array directly.
+        """
+        if plane_indices is None:
+            return list(range(self._num_planes))
+        if isinstance(plane_indices, slice):
+            return list(range(*plane_indices.indices(self._num_planes)))
+        candidates = np.atleast_1d(plane_indices)
+        if candidates.dtype == bool:
+            # A boolean mask selects planes, it does not name them by index.
+            candidates = np.flatnonzero(candidates)
+        indices = []
+        for raw in candidates:
+            index = int(raw)
+            if index < 0:
+                index += self._num_planes
+            if not 0 <= index < self._num_planes:
+                raise IndexError(f"Plane index {int(raw)} out of range for {self._num_planes} planes")
+            indices.append(index)
+        return indices
+
+
+class StackPlanesImaging(BaseImaging):
+    """Imaging proxy that stacks several imaging objects along the plane axis.
+
+    All inputs must share the same epoch structure (number of epochs and the
+    per-epoch frame counts), the same ``(height, width)``, sampling frequency
+    and dtype. The resulting object has ``sum(num_planes)`` planes and pulls
+    pixels lazily from the inputs — no data is copied.
+
+    Parameters
+    ----------
+    imagings : sequence of BaseImaging
+        Two or more imaging objects covering the same field of view at the
+        same timestamps, each providing one or more planes.
+    """
+
+    def __init__(self, imagings: Sequence[BaseImaging]):
+        imagings = list(imagings)
+        if len(imagings) < 2:
+            raise ValueError("stack_planes requires at least two imaging objects")
+        for i, im in enumerate(imagings):
+            if not isinstance(im, BaseImaging):
+                raise TypeError(f"Input {i} is not a BaseImaging (got {type(im).__name__})")
+
+        ref = imagings[0]
+        num_epochs = ref.get_num_epochs()
+        height, width = int(ref.shape[0]), int(ref.shape[1])
+        fs = ref.sampling_frequency
+        dtype = ref.get_dtype()
+        ref_samples = [ref.epochs[e].get_num_samples() for e in range(num_epochs)]
+
+        for i, im in enumerate(imagings[1:], start=1):
+            if im.get_num_epochs() != num_epochs:
+                raise ValueError(f"Input {i} has {im.get_num_epochs()} epochs but input 0 has {num_epochs}")
+            if (int(im.shape[0]), int(im.shape[1])) != (height, width):
+                raise ValueError(
+                    f"Input {i} has frame shape ({im.shape[0]}, {im.shape[1]}) " f"but input 0 has ({height}, {width})"
+                )
+            if im.sampling_frequency != fs:
+                raise ValueError(f"Input {i} sampling frequency {im.sampling_frequency} disagrees with input 0 ({fs})")
+            if np.dtype(im.get_dtype()) != np.dtype(dtype):
+                raise ValueError(f"Input {i} dtype {im.get_dtype()} disagrees with input 0 ({dtype})")
+            samples = [im.epochs[e].get_num_samples() for e in range(num_epochs)]
+            if samples != ref_samples:
+                raise ValueError(f"Input {i} per-epoch frame counts {samples} disagree with input 0 ({ref_samples})")
+
+        planes_per_parent = [int(im.num_planes) for im in imagings]
+        total_planes = sum(planes_per_parent)
+        BaseImaging.__init__(self, sampling_frequency=fs, shape=(height, width, total_planes))
+
+        for epoch_index in range(num_epochs):
+            parent_epochs = [im.epochs[epoch_index] for im in imagings]
+            self.add_epoch(_StackedPlanesEpoch(parent_epochs, height, width, planes_per_parent, dtype))
+
+        self._parents = imagings
+        self._kwargs = {"imagings": imagings}
+        self.name = f"Stacked planes ({total_planes} planes from {len(imagings)} objects)"
+
+
+def stack_planes(*imagings: BaseImaging) -> StackPlanesImaging:
+    """Stack imaging objects along the plane axis into one multi-plane volume.
+
+    Accepts the objects either as separate arguments (``stack_planes(a, b)``)
+    or as a single sequence (``stack_planes([a, b])``).
+
+    Parameters
+    ----------
+    *imagings : BaseImaging
+        Two or more imaging objects of the same FOV / timestamps; see
+        :class:`StackPlanesImaging`.
+
+    Returns
+    -------
+    StackPlanesImaging
+        A lazy multi-plane view over the inputs.
+    """
+    if len(imagings) == 1 and isinstance(imagings[0], (list, tuple)):
+        items: Sequence[BaseImaging] = imagings[0]
+    else:
+        items = imagings
+    return StackPlanesImaging(items)

--- a/src/photon_mosaic/core/stack.py
+++ b/src/photon_mosaic/core/stack.py
@@ -166,6 +166,9 @@ class StackPlanesImaging(BaseImaging):
         total_planes = sum(planes_per_parent)
         BaseImaging.__init__(self, sampling_frequency=fs, shape=(height, width, total_planes))
 
+        # The stacked volume is registered only if every input is.
+        self.is_registered = all(im.is_registered for im in imagings)
+
         for epoch_index in range(num_epochs):
             parent_epochs = [im.epochs[epoch_index] for im in imagings]
             self.add_epoch(_StackedPlanesEpoch(parent_epochs, height, width, planes_per_parent, dtype))

--- a/src/photon_mosaic/core/tests/test_baseimaging.py
+++ b/src/photon_mosaic/core/tests/test_baseimaging.py
@@ -116,6 +116,26 @@ def test_baseimaging_constructor_with_2d_dhape():
     assert base_imaging.shape == (50, 50, 1)
 
 
+def test_baseimaging_is_registered_defaults_false_and_is_settable():
+    imaging = BaseImaging(sampling_frequency=15.0, shape=(8, 8))
+    assert imaging.is_registered is False
+
+    imaging.is_registered = True
+    assert imaging.is_registered is True
+
+    # The flag can also be set at construction
+    registered = BaseImaging(sampling_frequency=15.0, shape=(8, 8), is_registered=True)
+    assert registered.is_registered is True
+
+
+def test_baseimaging_is_registered_propagates_via_copy_metadata():
+    parent = BaseImaging(sampling_frequency=15.0, shape=(8, 8), is_registered=True)
+    child = BaseImaging(sampling_frequency=15.0, shape=(8, 8))
+    assert child.is_registered is False
+    parent.copy_metadata(child)
+    assert child.is_registered is True
+
+
 def test_baseimaging_multi_epoch_requires_epoch_index():
     sf = 10.0
     h, w = 3, 4

--- a/src/photon_mosaic/core/tests/test_split.py
+++ b/src/photon_mosaic/core/tests/test_split.py
@@ -2,7 +2,12 @@ import numpy as np
 import pytest
 
 from photon_mosaic.core.generators import generate_random_imaging
-from photon_mosaic.core.split import SelectEpochImaging, split_epochs
+from photon_mosaic.core.split import (
+    SelectEpochImaging,
+    SplitEpochAtFramesImaging,
+    split_epoch_at_frames,
+    split_epochs,
+)
 
 
 def test_split_epoch_with_single_index_returns_single_epoch_proxy():
@@ -45,3 +50,32 @@ def test_split_epoch_raises_on_invalid_indices():
 
     with pytest.raises(TypeError):
         _ = split_epochs(imaging, [0, False])
+
+
+def test_split_epoch_at_frames_produces_contiguous_sub_epochs():
+    imaging = generate_random_imaging(num_frames=(20,), height=4, width=5, sampling_frequency=10.0, seed=3)
+    full = imaging.get_series(epoch_index=0)
+
+    sub = split_epoch_at_frames(imaging, 0, [7, 13])
+
+    assert isinstance(sub, SplitEpochAtFramesImaging)
+    assert sub.get_num_epochs() == 3
+    assert [sub.get_num_samples(segment_index=i) for i in range(3)] == [7, 6, 7]
+    np.testing.assert_array_equal(sub.get_series(epoch_index=0), full[:7])
+    np.testing.assert_array_equal(sub.get_series(epoch_index=1), full[7:13])
+    np.testing.assert_array_equal(sub.get_series(epoch_index=2), full[13:])
+
+
+def test_split_epoch_at_frames_validates_boundaries():
+    imaging = generate_random_imaging(num_frames=(10,), height=3, width=3, sampling_frequency=10.0, seed=4)
+
+    with pytest.raises(IndexError):
+        _ = split_epoch_at_frames(imaging, 1, [3])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [0])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [10])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [5, 5])
+    with pytest.raises(ValueError):
+        _ = split_epoch_at_frames(imaging, 0, [5, 3])

--- a/src/photon_mosaic/core/tests/test_stack.py
+++ b/src/photon_mosaic/core/tests/test_stack.py
@@ -190,6 +190,19 @@ def test_stack_accepts_single_sequence():
     assert joined.get_num_planes() == 2
 
 
+def test_stack_is_registered_only_when_all_inputs_are():
+    a = _imaging(5, 1, seed=8)
+    b = _imaging(5, 1, seed=9)
+
+    assert stack_planes(a, b).is_registered is False
+
+    a.is_registered = True
+    assert stack_planes(a, b).is_registered is False  # b still unregistered
+
+    b.is_registered = True
+    assert stack_planes(a, b).is_registered is True
+
+
 def test_stack_rejects_mismatched_inputs():
     a = _imaging(8, 1, seed=10)
 

--- a/src/photon_mosaic/core/tests/test_stack.py
+++ b/src/photon_mosaic/core/tests/test_stack.py
@@ -1,0 +1,218 @@
+import numpy as np
+import pytest
+
+from photon_mosaic.core.generators import generate_random_imaging
+from photon_mosaic.core.stack import StackPlanesImaging, stack_planes
+
+
+def _imaging(num_frames, planes, seed):
+    return generate_random_imaging(
+        num_frames=num_frames, height=5, width=6, sampling_frequency=20.0, num_planes=planes, seed=seed
+    )
+
+
+def test_stack_two_single_plane_objects():
+    a = _imaging(8, 1, seed=0)
+    b = _imaging(8, 1, seed=1)
+
+    joined = stack_planes(a, b)
+
+    assert isinstance(joined, StackPlanesImaging)
+    assert joined.get_num_planes() == 2
+    assert tuple(joined.shape) == (5, 6, 2)
+
+    out = joined.get_series()
+    assert out.shape == (8, 5, 6, 2)
+    np.testing.assert_array_equal(out[..., 0], a.get_series()[..., 0])
+    np.testing.assert_array_equal(out[..., 1], b.get_series()[..., 0])
+
+
+def test_stack_multi_plane_objects_and_plane_selection():
+    a = _imaging(7, 2, seed=2)
+    b = _imaging(7, 3, seed=3)
+
+    joined = stack_planes(a, b)
+    assert joined.get_num_planes() == 5
+
+    full = joined.get_series()
+    assert full.shape == (7, 5, 6, 5)
+    np.testing.assert_array_equal(full[..., 0:2], a.get_series())
+    np.testing.assert_array_equal(full[..., 2:5], b.get_series())
+
+    # plane selection crossing the boundary between the two inputs
+    sel = joined.get_series(plane_ids=[1, 3])
+    assert sel.shape == (7, 5, 6, 2)
+    np.testing.assert_array_equal(sel[..., 0], a.get_series()[..., 1])
+    np.testing.assert_array_equal(sel[..., 1], b.get_series()[..., 1])
+
+
+def test_stack_preserves_requested_plane_order():
+    """An out-of-order request must come back in the requested order.
+
+    Planes are gathered parent by parent, so without an explicit reorder a
+    request for [3, 0] would silently return [0, 3].
+    """
+    a = _imaging(6, 2, seed=20)
+    b = _imaging(6, 2, seed=21)
+
+    joined = stack_planes(a, b)
+
+    out = joined.get_series(plane_ids=[3, 0])
+    assert out.shape == (6, 5, 6, 2)
+    np.testing.assert_array_equal(out[..., 0], b.get_series()[..., 1])
+    np.testing.assert_array_equal(out[..., 1], a.get_series()[..., 0])
+
+    # within a single parent, too
+    within = joined.get_series(plane_ids=[1, 0])
+    np.testing.assert_array_equal(within[..., 0], a.get_series()[..., 1])
+    np.testing.assert_array_equal(within[..., 1], a.get_series()[..., 0])
+
+
+def test_stack_does_not_read_parents_without_requested_planes():
+    """Planes are pulled only from the parents that hold them.
+
+    Guards the push-down: a naive implementation reads every parent in full and
+    slices afterwards, which costs one full read per plane of the volume.
+    """
+    a = _imaging(6, 1, seed=22)
+    b = _imaging(6, 1, seed=23)
+    c = _imaging(6, 1, seed=24)
+
+    joined = stack_planes(a, b, c)
+
+    calls = []
+    for index, epoch in enumerate(joined.epochs[0]._parent_epochs):
+        original = epoch.get_series
+
+        def spy(start, end, plane_indices=None, _i=index, _f=original):
+            calls.append(_i)
+            return _f(start, end, plane_indices)
+
+        epoch.get_series = spy
+
+    out = joined.get_series(plane_ids=[1])
+
+    assert calls == [1]
+    np.testing.assert_array_equal(out[..., 0], b.get_series()[..., 0])
+
+
+def test_stack_empty_plane_selection_returns_empty_plane_axis():
+    a = _imaging(6, 1, seed=27)
+    b = _imaging(6, 1, seed=28)
+    joined = stack_planes(a, b)
+
+    out = joined.get_series(plane_ids=[])
+    assert out.shape == (6, 5, 6, 0)
+    assert out.dtype == a.get_dtype()
+
+
+def test_stack_accepts_negative_plane_indices():
+    """Negative indices count from the end, as they do on the sibling epochs."""
+    a = _imaging(6, 2, seed=29)
+    b = _imaging(6, 1, seed=30)
+    joined = stack_planes(a, b)
+
+    last = joined.epochs[0].get_series(0, 6, np.array([-1]))
+    np.testing.assert_array_equal(last[..., 0], b.get_series()[..., 0])
+
+    mixed = joined.epochs[0].get_series(0, 6, np.array([-1, 0]))
+    np.testing.assert_array_equal(mixed[..., 0], b.get_series()[..., 0])
+    np.testing.assert_array_equal(mixed[..., 1], a.get_series()[..., 0])
+
+
+def test_stack_treats_a_boolean_mask_as_a_mask():
+    """A boolean array selects planes; it does not name them by index."""
+    a = _imaging(6, 2, seed=33)
+    b = _imaging(6, 2, seed=34)
+    joined = stack_planes(a, b)
+
+    out = joined.epochs[0].get_series(0, 6, np.array([True, False, True, False]))
+    assert out.shape == (6, 5, 6, 2)
+    np.testing.assert_array_equal(out[..., 0], a.get_series()[..., 0])
+    np.testing.assert_array_equal(out[..., 1], b.get_series()[..., 0])
+
+
+def test_stack_reads_whole_parents_by_slice_not_index_array():
+    """A parent giving up all its planes is asked with a slice.
+
+    An index array would force an advanced-indexing copy, making the common
+    whole-volume read more expensive than it needs to be.
+    """
+    a = _imaging(6, 2, seed=31)
+    b = _imaging(6, 2, seed=32)
+    joined = stack_planes(a, b)
+
+    seen = []
+    for epoch in joined.epochs[0]._parent_epochs:
+        original = epoch.get_series
+
+        def spy(start, end, plane_indices=None, _f=original):
+            seen.append(plane_indices)
+            return _f(start, end, plane_indices)
+
+        epoch.get_series = spy
+
+    _ = joined.get_series()
+
+    assert all(isinstance(s, slice) for s in seen), seen
+
+
+def test_stack_rejects_out_of_range_plane_index():
+    a = _imaging(5, 1, seed=25)
+    b = _imaging(5, 1, seed=26)
+    joined = stack_planes(a, b)
+
+    with pytest.raises(IndexError):
+        _ = joined.epochs[0].get_series(0, 5, np.array([2]))
+
+    with pytest.raises(IndexError):
+        _ = joined.epochs[0].get_series(0, 5, np.array([-3]))
+
+
+def test_stack_multi_epoch():
+    a = _imaging((4, 6), 1, seed=4)
+    b = _imaging((4, 6), 2, seed=5)
+
+    joined = stack_planes(a, b)
+    assert joined.get_num_epochs() == 2
+    assert joined.get_num_planes() == 3
+
+    out1 = joined.get_series(epoch_index=1)
+    assert out1.shape == (6, 5, 6, 3)
+    np.testing.assert_array_equal(out1[..., 0:1], a.get_series(epoch_index=1))
+    np.testing.assert_array_equal(out1[..., 1:3], b.get_series(epoch_index=1))
+
+
+def test_stack_accepts_single_sequence():
+    a = _imaging(5, 1, seed=6)
+    b = _imaging(5, 1, seed=7)
+    joined = stack_planes([a, b])
+    assert joined.get_num_planes() == 2
+
+
+def test_stack_rejects_mismatched_inputs():
+    a = _imaging(8, 1, seed=10)
+
+    with pytest.raises(ValueError, match="at least two"):
+        _ = stack_planes(a)
+
+    # mismatched frame counts
+    b_short = _imaging(7, 1, seed=11)
+    with pytest.raises(ValueError, match="frame counts"):
+        _ = stack_planes(a, b_short)
+
+    # mismatched number of epochs
+    b_epochs = _imaging((8, 3), 1, seed=12)
+    with pytest.raises(ValueError, match="epochs"):
+        _ = stack_planes(a, b_epochs)
+
+    # mismatched frame shape
+    b_shape = generate_random_imaging(num_frames=8, height=9, width=6, sampling_frequency=20.0, num_planes=1, seed=13)
+    with pytest.raises(ValueError, match="frame shape"):
+        _ = stack_planes(a, b_shape)
+
+
+def test_stack_rejects_non_imaging_input():
+    a = _imaging(5, 1, seed=14)
+    with pytest.raises(TypeError):
+        _ = stack_planes(a, "not an imaging")

--- a/src/photon_mosaic/extractors/__init__.py
+++ b/src/photon_mosaic/extractors/__init__.py
@@ -3,12 +3,20 @@ from .roiextractors import (
     BaseROIExtractorImaging,
     BaseROIExtractorImagingEpoch,
 )
+from .suite2pbin import (
+    Suite2pImaging,
+    read_suite2p_binary,
+    read_suite2p_full,
+)
 from .suite2prois import Suite2pRois, read_suite2p_rois
 
 # Build __all__ to include all exports
 __all__ = [
     "BaseROIExtractorImaging",
     "BaseROIExtractorImagingEpoch",
+    "Suite2pImaging",
+    "read_suite2p_binary",
+    "read_suite2p_full",
     "Suite2pRois",
     "read_suite2p_rois",
 ]

--- a/src/photon_mosaic/extractors/suite2pbin.py
+++ b/src/photon_mosaic/extractors/suite2pbin.py
@@ -1,0 +1,233 @@
+"""Load suite2p registered binary movies as photon-mosaic imaging objects.
+
+Suite2p stores the registered functional movie as one ``data.bin`` per plane
+under ``<suite2p_root>/plane{i}/`` together with an ``ops.npy`` describing the
+geometry (``Ly``, ``Lx``, ``fs``, ``nchannels``) and the per-source-file frame
+counts (``frames_per_file``). When two functional channels are present the
+second channel lives next to ``data.bin`` as ``data_chan2.bin``.
+
+Following issue #77, each :class:`Suite2pImaging` loads **one plane** as a
+:class:`~photon_mosaic.core.binaryimaging.BinaryImaging` (use cases 1-2).
+Multi-plane volumes are built by stitching single-plane objects with
+:func:`~photon_mosaic.core.stack.stack_planes`; the convenience
+:func:`read_suite2p_full` does this for a whole suite2p folder. Per-source-file
+epochs are recovered with :meth:`Suite2pImaging.into_epochs` (use case 3).
+
+The module-level aliases mirror the ROI extractor's convention:
+``read_suite2p_binary`` is :class:`Suite2pImaging` (one plane) and
+``read_suite2p_full`` loads and stitches a whole folder.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from photon_mosaic.core.baseimaging import BaseImaging
+from photon_mosaic.core.binaryimaging import BinaryImaging
+from photon_mosaic.core.split import SplitEpochAtFramesImaging, split_epoch_at_frames
+from photon_mosaic.core.stack import stack_planes
+
+SUITE2P_BIN_DTYPE = np.int16  # suite2p writes registered movies as int16
+SUITE2P_PLANE_DIR_PREFIX = "plane"
+
+
+def _list_plane_dirs(root: Path) -> list[Path]:
+    """Return ``plane{i}/`` subdirectories of a suite2p root, sorted by plane index."""
+    candidates = [p for p in root.iterdir() if p.is_dir() and p.name.startswith(SUITE2P_PLANE_DIR_PREFIX)]
+
+    def _plane_index(p: Path) -> int:
+        try:
+            return int(p.name[len(SUITE2P_PLANE_DIR_PREFIX) :])
+        except ValueError:
+            return -1
+
+    valid = sorted([p for p in candidates if _plane_index(p) >= 0], key=_plane_index)
+    if not valid:
+        raise FileNotFoundError(f"No plane*/ directories found under {root}")
+    return valid
+
+
+def _load_ops(plane_dir: Path) -> dict[str, Any]:
+    ops_path = plane_dir / "ops.npy"
+    if not ops_path.exists():
+        raise FileNotFoundError(f"Missing ops.npy in {plane_dir}")
+    return np.load(ops_path, allow_pickle=True).item()
+
+
+def _data_bin_name(chan: int) -> str:
+    if chan == 1:
+        return "data.bin"
+    if chan == 2:
+        return "data_chan2.bin"
+    raise ValueError(f"chan must be 1 or 2, got {chan}")
+
+
+def _resolve_plane_dir(path: Path) -> Path:
+    """Resolve ``path`` to a single suite2p plane directory.
+
+    Accepts either a plane directory (one that contains ``ops.npy``) or a
+    suite2p run root that holds exactly one ``plane*/``. A root with several
+    planes is rejected with a pointer to the multi-plane entry points.
+    """
+    if (path / "ops.npy").exists():
+        return path
+    plane_dirs = _list_plane_dirs(path)
+    if len(plane_dirs) != 1:
+        raise ValueError(
+            f"{path} contains {len(plane_dirs)} planes; Suite2pImaging loads a single plane. "
+            f"Use read_suite2p_full({str(path)!r}) or stack_planes(...) to build a multi-plane volume."
+        )
+    return plane_dirs[0]
+
+
+class Suite2pImaging(BinaryImaging):
+    """A single plane of a suite2p registered movie, exposed as a :class:`BinaryImaging`.
+
+    suite2p writes one registered ``data.bin`` per plane; this class memory-maps
+    that binary lazily (no pixels are copied) and marks the movie as registered
+    (:attr:`~photon_mosaic.core.baseimaging.BaseImaging.is_registered` is ``True``).
+    One object holds exactly one plane: following issue #77, a multi-plane volume is
+    assembled from several single-plane objects with
+    :func:`~photon_mosaic.core.stack.stack_planes`, or in one step for a
+    whole suite2p folder via :func:`read_suite2p_full`.
+
+    Parameters
+    ----------
+    folder_path : str | Path
+        A suite2p plane directory (one that contains ``data.bin`` and ``ops.npy``),
+        or a suite2p run root holding a single ``plane0/``. A multi-plane root is
+        rejected with a pointer to :func:`read_suite2p_full` / ``stack_planes``.
+    chan : int, default: 1
+        Functional channel to load (``1`` -> ``data.bin``, ``2`` -> ``data_chan2.bin``).
+
+    Attributes
+    ----------
+    frames_per_file_per_epoch : list
+        The suite2p per-source-file frame counts (``ops['frames_per_file']``) as a
+        one-element list, so the single epoch can be subdivided into per-file
+        sub-epochs with :meth:`into_epochs`. ``[None]`` when the run did not
+        record ``frames_per_file``.
+    chan, nchannels : int
+        The functional channel loaded, and the number of channels in the run.
+    suite2p_root : str
+        Absolute path to the plane directory this object was loaded from.
+    """
+
+    def __init__(self, folder_path, chan: int = 1):
+        plane_dir = _resolve_plane_dir(Path(folder_path))
+        ops = _load_ops(plane_dir)
+        Ly, Lx = int(ops["Ly"]), int(ops["Lx"])
+        fs = float(ops["fs"])
+        nchannels = int(ops["nchannels"])
+
+        if chan > nchannels:
+            raise FileNotFoundError(
+                f"Requested chan={chan} but ops['nchannels']={nchannels}; "
+                f"no per-plane binary exists for this channel"
+            )
+        bin_path = plane_dir / _data_bin_name(chan)
+        if not bin_path.exists():
+            raise FileNotFoundError(f"Missing {bin_path.name} in {plane_dir}")
+
+        # A single plane is one interleaved binary -> a plain BinaryImaging. We
+        # keep BinaryImaging's binary spec in _kwargs untouched so this object
+        # stays binary-compatible (get_binary_description works); multi-plane
+        # volumes are assembled separately by stack_planes.
+        BinaryImaging.__init__(
+            self,
+            file_paths=str(bin_path),
+            sampling_frequency=fs,
+            shape=(Ly, Lx, 1),
+            dtype=SUITE2P_BIN_DTYPE,
+            file_offset=0,
+        )
+
+        # suite2p binaries are the registered (motion-corrected) movie
+        self.is_registered = True
+
+        fpf_raw = ops.get("frames_per_file")
+        frames_per_file = None if fpf_raw is None else np.asarray(fpf_raw, dtype=int).tolist()
+        # Stored as a one-epoch list so into_epochs can subdivide it.
+        self.frames_per_file_per_epoch: list[list[int] | None] = [frames_per_file]
+
+        self.chan: int = chan
+        self.nchannels: int = nchannels
+        self.suite2p_root: str = str(plane_dir.absolute())
+        self.name = f"Suite2p plane chan{chan}"
+
+    def into_epochs(self) -> SplitEpochAtFramesImaging:
+        """Split this movie into one epoch per source acquisition file.
+
+        suite2p concatenates the source acquisition files into a single registered
+        movie and records the per-file frame counts in ``ops['frames_per_file']``.
+        This recovers one epoch per original file (use case 3 of issue #77) by
+        recycling :func:`~photon_mosaic.core.split.split_epoch_at_frames` at those
+        boundaries — pixels stay lazy, nothing is re-read.
+
+        Returns
+        -------
+        SplitEpochAtFramesImaging
+            A lazy view with one epoch per source acquisition file.
+
+        Raises
+        ------
+        ValueError
+            If the run did not record ``ops['frames_per_file']``, or those counts
+            do not sum to the movie's frame count (a malformed ``ops``).
+        """
+        frames_per_file = self.frames_per_file_per_epoch[0]
+        if frames_per_file is None:
+            raise ValueError("ops['frames_per_file'] was not recorded; cannot split this run into files")
+        n_samples = self.epochs[0].get_num_samples()
+        if sum(frames_per_file) != n_samples:
+            raise ValueError(
+                f"ops['frames_per_file'] sums to {sum(frames_per_file)} but the movie has "
+                f"{n_samples} frames; refusing to split a malformed run"
+            )
+        boundaries = np.cumsum(frames_per_file)[:-1].tolist()
+        return split_epoch_at_frames(self, 0, boundaries)
+
+
+def read_suite2p_full(
+    folder_path,
+) -> "BaseImaging | tuple[BaseImaging, BaseImaging]":
+    """Load a suite2p output folder, one imaging object per functional channel.
+
+    Each plane is loaded as a single-plane :class:`Suite2pImaging` and the planes
+    are stitched into one volume with
+    :func:`~photon_mosaic.core.stack.stack_planes` (use cases 1-2 of
+    issue #77).
+
+    Parameters
+    ----------
+    folder_path : str | Path
+        Path to a suite2p output root (the parent of ``plane0/``, ``plane1/``, ...).
+
+    Returns
+    -------
+    BaseImaging or (BaseImaging, BaseImaging)
+        A single imaging object when the run has one functional channel; a
+        ``(chan1, chan2)`` tuple when ``nchannels == 2``. Single-plane runs
+        return the :class:`Suite2pImaging` directly; multi-plane runs return the
+        stitched volume.
+    """
+    root = Path(folder_path)
+    plane_dirs = _list_plane_dirs(root)
+    nchannels = int(_load_ops(plane_dirs[0])["nchannels"])
+
+    def _volume(chan: int) -> BaseImaging:
+        planes = [Suite2pImaging(plane_dir, chan=chan) for plane_dir in plane_dirs]
+        # stack_planes already propagates is_registered from the planes; the
+        # stitched volume stays a plain multi-plane imaging (no suite2p specifics).
+        return planes[0] if len(planes) == 1 else stack_planes(*planes)
+
+    chan1 = _volume(1)
+    if nchannels == 1:
+        return chan1
+    return chan1, _volume(2)
+
+
+# Aliases mirroring the ROI extractor's read_* convention (cf. read_suite2p_rois).
+# read_suite2p_binary loads one plane's binary; read_suite2p_full loads a folder.
+read_suite2p_binary = Suite2pImaging

--- a/src/photon_mosaic/extractors/tests/test_suite2pbin.py
+++ b/src/photon_mosaic/extractors/tests/test_suite2pbin.py
@@ -1,0 +1,248 @@
+"""Tests for the Suite2pImaging extractor.
+
+These tests build synthetic suite2p output trees on disk (per-plane ``data.bin``
+plus ``ops.npy``) so the extractor can be exercised end-to-end without a real
+suite2p run. The on-disk layout matches what suite2p produces in v0.14+.
+
+Following issue #77, ``Suite2pImaging`` loads a single plane; multi-plane
+volumes are assembled with ``stack_planes`` (used internally by
+``read_suite2p_full``).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from photon_mosaic.core.split import split_epoch_at_frames
+from photon_mosaic.core.stack import stack_planes
+from photon_mosaic.extractors.suite2pbin import (
+    Suite2pImaging,
+    read_suite2p_binary,
+    read_suite2p_full,
+)
+
+SUITE2P_DTYPE = np.int16
+
+
+def _write_suite2p_run(
+    root: Path,
+    *,
+    n_frames: int,
+    Ly: int,
+    Lx: int,
+    nplanes: int,
+    nchannels: int = 1,
+    fs: float = 30.0,
+    frames_per_file: list[int] | None = None,
+    seed: int = 0,
+) -> dict[int, dict[int, np.ndarray]]:
+    """Write a synthetic suite2p output tree and return the source data per (plane, chan).
+
+    Returns ``{plane_index: {chan_index: array}}`` where each array has shape
+    ``(n_frames, Ly, Lx)`` and dtype int16, matching what the extractor should
+    read back.
+    """
+    rng = np.random.default_rng(seed)
+    written: dict[int, dict[int, np.ndarray]] = {}
+    for plane_idx in range(nplanes):
+        plane_dir = root / f"plane{plane_idx}"
+        plane_dir.mkdir(parents=True, exist_ok=True)
+
+        per_chan: dict[int, np.ndarray] = {}
+        for chan in range(1, nchannels + 1):
+            data = rng.integers(-10000, 10000, size=(n_frames, Ly, Lx)).astype(SUITE2P_DTYPE)
+            bin_name = "data.bin" if chan == 1 else "data_chan2.bin"
+            with open(plane_dir / bin_name, "wb") as f:
+                f.write(np.ascontiguousarray(data).tobytes(order="C"))
+            per_chan[chan] = data
+        written[plane_idx] = per_chan
+
+        ops = {
+            "Ly": Ly,
+            "Lx": Lx,
+            "nframes": n_frames,
+            "fs": fs,
+            "nplanes": nplanes,
+            "nchannels": nchannels,
+        }
+        if frames_per_file is not None:
+            ops["frames_per_file"] = np.asarray(frames_per_file, dtype=int)
+        np.save(plane_dir / "ops.npy", ops, allow_pickle=True)
+
+    return written
+
+
+def test_suite2p_imaging_single_plane_single_run(tmp_path: Path):
+    root = tmp_path / "run0"
+    n_frames, Ly, Lx = 12, 5, 7
+    written = _write_suite2p_run(root, n_frames=n_frames, Ly=Ly, Lx=Lx, nplanes=1, seed=42)
+
+    imaging = Suite2pImaging(root)
+    assert imaging.get_num_epochs() == 1
+    assert imaging.get_num_frames() == n_frames
+    assert tuple(imaging.shape) == (Ly, Lx, 1)
+    assert imaging.sampling_frequency == 30.0
+    assert imaging.chan == 1
+    assert imaging.nchannels == 1
+    # suite2p binaries are the registered movie
+    assert imaging.is_registered is True
+
+    out = imaging.get_series(0, n_frames)
+    np.testing.assert_array_equal(out[..., 0], written[0][1])
+
+    # A single plane still maps to a unique binary on disk.
+    assert imaging.is_binary_compatible()
+    desc = imaging.get_binary_description()
+    assert desc is not None
+
+
+def test_suite2p_imaging_accepts_plane_directory_directly(tmp_path: Path):
+    root = tmp_path / "run0"
+    _write_suite2p_run(root, n_frames=6, Ly=3, Lx=4, nplanes=2, seed=5)
+
+    # A plane directory (contains ops.npy) is accepted directly...
+    plane1 = Suite2pImaging(root / "plane1")
+    assert tuple(plane1.shape) == (3, 4, 1)
+    # ...while a multi-plane root is rejected with a pointer to read_suite2p_full.
+    with pytest.raises(ValueError, match="single plane"):
+        _ = Suite2pImaging(root)
+
+
+def test_stack_planes_of_single_plane_suite2p_objects(tmp_path: Path):
+    """Use case 1 of issue #77: load each plane, then stitch with stack_planes."""
+    root = tmp_path / "run0"
+    n_frames, Ly, Lx = 6, 4, 5
+    written = _write_suite2p_run(root, n_frames=n_frames, Ly=Ly, Lx=Lx, nplanes=2, seed=3)
+
+    plane0 = Suite2pImaging(root / "plane0")
+    plane1 = Suite2pImaging(root / "plane1")
+    assert tuple(plane0.shape) == (Ly, Lx, 1)
+
+    volume = stack_planes(plane0, plane1)
+    assert tuple(volume.shape) == (Ly, Lx, 2)
+    assert volume.is_registered is True
+
+    out = volume.get_series(0, n_frames)
+    assert out.shape == (n_frames, Ly, Lx, 2)
+    np.testing.assert_array_equal(out[..., 0], written[0][1])
+    np.testing.assert_array_equal(out[..., 1], written[1][1])
+
+
+def test_read_suite2p_stitches_planes(tmp_path: Path):
+    root = tmp_path / "run0"
+    n_frames, Ly, Lx, nplanes = 8, 4, 6, 3
+    written = _write_suite2p_run(root, n_frames=n_frames, Ly=Ly, Lx=Lx, nplanes=nplanes, seed=7)
+
+    imaging = read_suite2p_full(root)  # single channel -> one stitched volume
+    assert tuple(imaging.shape) == (Ly, Lx, nplanes)
+    assert imaging.is_registered is True
+
+    out = imaging.get_series(0, n_frames)
+    assert out.shape == (n_frames, Ly, Lx, nplanes)
+    for p in range(nplanes):
+        np.testing.assert_array_equal(out[..., p], written[p][1])
+
+
+def test_read_suite2p_two_channels_returns_pair(tmp_path: Path):
+    root = tmp_path / "run0"
+    n_frames, Ly, Lx = 5, 3, 4
+    written = _write_suite2p_run(root, n_frames=n_frames, Ly=Ly, Lx=Lx, nplanes=1, nchannels=2, seed=1)
+
+    result = read_suite2p_full(root)
+    assert isinstance(result, tuple)
+    chan1, chan2 = result
+    assert isinstance(chan1, Suite2pImaging) and isinstance(chan2, Suite2pImaging)
+    assert chan1.chan == 1 and chan2.chan == 2
+    assert tuple(chan1.shape) == (Ly, Lx, 1)
+    assert tuple(chan2.shape) == (Ly, Lx, 1)
+
+    np.testing.assert_array_equal(chan1.get_series(0, n_frames)[..., 0], written[0][1])
+    np.testing.assert_array_equal(chan2.get_series(0, n_frames)[..., 0], written[0][2])
+
+
+def test_read_suite2p_single_plane_single_channel_returns_one_object(tmp_path: Path):
+    root = tmp_path / "run0"
+    _write_suite2p_run(root, n_frames=6, Ly=3, Lx=3, nplanes=1, nchannels=1)
+    obj = read_suite2p_full(root)
+    assert isinstance(obj, Suite2pImaging)
+
+
+def test_read_suite2p_binary_alias_is_the_class(tmp_path: Path):
+    # Mirrors read_suite2p_rois = Suite2pRois: read_suite2p_binary IS the class.
+    assert read_suite2p_binary is Suite2pImaging
+    root = tmp_path / "run0"
+    _write_suite2p_run(root, n_frames=4, Ly=3, Lx=3, nplanes=1)
+    assert isinstance(read_suite2p_binary(root), Suite2pImaging)
+
+
+def test_suite2p_imaging_records_frames_per_file_metadata(tmp_path: Path):
+    root = tmp_path / "run0"
+    n_frames, Ly, Lx = 10, 3, 3
+    fpf = [3, 4, 3]
+    _write_suite2p_run(root, n_frames=n_frames, Ly=Ly, Lx=Lx, nplanes=1, frames_per_file=fpf)
+
+    imaging = Suite2pImaging(root)
+    assert imaging.frames_per_file_per_epoch == [fpf]
+
+    # The metadata should let us subdivide the epoch into per-source-tiff sub-epochs
+    boundaries = np.cumsum(fpf)[:-1].tolist()
+    sub = split_epoch_at_frames(imaging, 0, boundaries)
+    assert sub.get_num_epochs() == len(fpf)
+    assert [sub.get_num_samples(segment_index=i) for i in range(len(fpf))] == fpf
+
+
+def test_into_epochs_splits_at_file_boundaries(tmp_path: Path):
+    root = tmp_path / "run0"
+    n_frames, Ly, Lx = 10, 3, 4
+    fpf = [3, 4, 3]
+    written = _write_suite2p_run(root, n_frames=n_frames, Ly=Ly, Lx=Lx, nplanes=1, frames_per_file=fpf)
+
+    imaging = Suite2pImaging(root)
+    split = imaging.into_epochs()
+
+    assert split.get_num_epochs() == len(fpf)
+    assert [split.get_num_samples(segment_index=i) for i in range(len(fpf))] == fpf
+    # registered flag carried over from the suite2p parent
+    assert split.is_registered is True
+
+    # Concatenating the per-file epochs back recovers the original movie
+    recovered = np.concatenate([split.get_series(epoch_index=i)[..., 0] for i in range(len(fpf))], axis=0)
+    np.testing.assert_array_equal(recovered, written[0][1])
+
+
+def test_into_epochs_requires_frames_per_file(tmp_path: Path):
+    root = tmp_path / "run0"
+    _write_suite2p_run(root, n_frames=6, Ly=3, Lx=3, nplanes=1)  # no frames_per_file
+    imaging = Suite2pImaging(root)
+    with pytest.raises(ValueError, match="frames_per_file"):
+        _ = imaging.into_epochs()
+
+
+def test_into_epochs_rejects_frames_per_file_mismatch(tmp_path: Path):
+    root = tmp_path / "run0"
+    # ops declares per-file counts that do not sum to the actual frame count
+    _write_suite2p_run(root, n_frames=10, Ly=3, Lx=3, nplanes=1, frames_per_file=[3, 4])
+    imaging = Suite2pImaging(root)
+    with pytest.raises(ValueError, match="frames_per_file"):
+        _ = imaging.into_epochs()
+
+
+def test_read_suite2p_rejects_inconsistent_geometry_across_planes(tmp_path: Path):
+    root = tmp_path / "run0"
+    _write_suite2p_run(root, n_frames=5, Ly=3, Lx=3, nplanes=2)
+    # Corrupt plane 1's ops.npy to claim a different Lx
+    ops1 = np.load(root / "plane1" / "ops.npy", allow_pickle=True).item()
+    ops1["Lx"] = 99
+    np.save(root / "plane1" / "ops.npy", ops1, allow_pickle=True)
+
+    # stack_planes (via read_suite2p_full) refuses to stitch mismatched planes.
+    with pytest.raises(ValueError, match="frame shape"):
+        _ = read_suite2p_full(root)
+
+
+def test_suite2p_imaging_rejects_missing_channel(tmp_path: Path):
+    root = tmp_path / "run0"
+    _write_suite2p_run(root, n_frames=5, Ly=3, Lx=3, nplanes=1, nchannels=1)
+    with pytest.raises(FileNotFoundError):
+        _ = Suite2pImaging(root, chan=2)

--- a/src/photon_mosaic/preprocessing/suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/suite2p_registration.py
@@ -477,6 +477,10 @@ class RegisterSuite2PImaging(BasePreprocessor):
             epoch = RegisterSuite2PImagingEpoch(parent_epoch, motion, epoch_idx, **kwargs)
             self.add_epoch(epoch)
 
+        # The output of registration is, by definition, registered (overrides the
+        # parent's flag copied by BasePreprocessor.copy_metadata).
+        self.is_registered = True
+
         self._kwargs = dict(imaging=imaging, motion=motion, **kwargs)
 
 

--- a/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
+++ b/src/photon_mosaic/preprocessing/tests/test_suite2p_registration.py
@@ -121,8 +121,13 @@ class TestComputeMotionSuite2p:
         assert motion.num_epochs == 1
         assert motion.displacements[0].shape == (6, 1, 2)
 
+        # The raw input is not registered; the registration output is
+        assert imaging.is_registered is False
+        registered_imaging = RegisterSuite2PImaging(imaging, motion)
+        assert registered_imaging.is_registered is True
+
         # Applying the computed motion should restore the unshifted template (first frame)
-        registered = RegisterSuite2PImaging(imaging, motion).epochs[0].get_series(0, 6)
+        registered = registered_imaging.epochs[0].get_series(0, 6)
         np.testing.assert_allclose(registered, registered[0:1].repeat(6, axis=0), atol=1e-3)
 
     def test_kwargs_override_settings_and_batching(self):


### PR DESCRIPTION
Second of two PRs splitting #83. **Stacked on #118** — review that one first; the diff here shows only the extractor once #118 merges.

Loads a pre-computed suite2p run into photon-mosaic, one plane at a time.

- **`Suite2pImaging`** — a single plane's `data.bin` as a lazy, memmapped `BinaryImaging`.
- **`read_suite2p_full(folder)`** — loads a whole run and stacks it, one object per channel.
- **`into_epochs()`** — one epoch per source file, from `ops['frames_per_file']`.
- **`is_registered`** — a `BaseImaging` flag for whether a movie holds motion-corrected data, stored as an annotation so `copy_metadata` carries it to proxy and preprocessor views. `RegisterSuite2PImaging` sets it, and `stack_planes` sets it only when every input is registered.
- Notebook `examples/suite2p_extractor.ipynb` covering per-plane load plus stitch, whole-folder load, per-file epochs, and per-plane ROI pairing.

Multi-plane volumes are built by composition with `stack_planes` rather than a bespoke volumetric class. ROIs pair **per plane**, via `read_suite2p_rois(plane).register_imaging(plane)`; a volumetric ROI object is deferred to #108.

Closes #77.