### PR TITLE
explicit delegate get_series to splitting parent

### DIFF
--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from .baseimaging import BaseImaging
 
 
@@ -41,6 +43,22 @@ class SelectEpochImaging(BaseImaging):
             "imaging": imaging,
             "epoch_indices": normalized_epoch_indices,
         }
+
+    def get_series(
+        self,
+        start_frame: int | None = None,
+        end_frame: int | None = None,
+        plane_ids: list | np.ndarray | None = None,
+        epoch_index: int | None = None,
+    ) -> np.ndarray:
+        # parent may want to do further operations to the series before returning
+        # so we explicitly delegate to them rather than relying on BaseImaging.
+        return self._parent.get_series(
+            start_frame=start_frame,
+            end_frame=end_frame,
+            plane_ids=plane_ids,
+            epoch_index=epoch_index,
+        )
 
 
 def split_epochs(imaging: BaseImaging, epoch_indices: int | list[int]) -> SelectEpochImaging:

--- a/src/photon_mosaic/core/split.py
+++ b/src/photon_mosaic/core/split.py
@@ -34,9 +34,11 @@ class SelectEpochImaging(BaseImaging):
         BaseImaging.__init__(self, sampling_frequency=imaging.sampling_frequency, shape=imaging.shape)
         imaging.copy_metadata(self)
 
-        for epoch_index in normalized_epoch_indices:
+        self._selected_epoch_indices = {}
+        for i, epoch_index in enumerate(normalized_epoch_indices):
             imaging_epoch = imaging.epochs[epoch_index]
             self.add_epoch(imaging_epoch)
+            self._selected_epoch_indices[i] = epoch_index
 
         self._parent = imaging
         self._kwargs = {
@@ -53,11 +55,16 @@ class SelectEpochImaging(BaseImaging):
     ) -> np.ndarray:
         # parent may want to do further operations to the series before returning
         # so we explicitly delegate to them rather than relying on BaseImaging.
+        # We also remap selected epoch indices relative to the parent
+        if epoch_index is None:
+            selected_epoch_index = self._selected_epoch_indices[0]
+        else:
+            selected_epoch_index = self._selected_epoch_indices[epoch_index]
         return self._parent.get_series(
             start_frame=start_frame,
             end_frame=end_frame,
             plane_ids=plane_ids,
-            epoch_index=epoch_index,
+            epoch_index=selected_epoch_index,
         )
 
 

--- a/src/photon_mosaic/core/tests/test_split.py
+++ b/src/photon_mosaic/core/tests/test_split.py
@@ -28,6 +28,19 @@ def test_split_epoch_with_multiple_indices_preserves_order():
     assert split_imaging.epochs[1] is imaging.epochs[0]
 
 
+def test_split_repeatly():
+    imaging = generate_random_imaging(num_frames=(4, 6, 8, 10), height=5, width=7, sampling_frequency=20.0, seed=0)
+
+    split_imaging = split_epochs(imaging, [1, 2, 3])  # take last three epochs
+    split_split_imaging = split_epochs(split_imaging, [1])  # take middle of last three epochs
+
+    assert split_split_imaging.get_num_epochs() == 1
+    np.testing.assert_allclose(split_split_imaging.get_series(epoch_index=0), split_imaging.get_series(epoch_index=1))
+    np.testing.assert_allclose(split_split_imaging.get_series(epoch_index=0), imaging.get_series(epoch_index=2))
+    assert split_split_imaging.epochs[0] is split_imaging.epochs[1]
+    assert split_split_imaging.epochs[0] is imaging.epochs[2]
+
+
 def test_split_epoch_raises_on_invalid_indices():
     imaging = generate_random_imaging(num_frames=(3, 5), height=4, width=6, sampling_frequency=15.0, seed=2)
 


### PR DESCRIPTION
Fixes #120 

This PR adds an explicit call to the parent imaging's `get_series` function from the `SelectEpochImaging` class (including remapping indices), because before it was ignoring any modifications to `get_series` any of its parents were doing, and going directly to the BaseImaging `get_series` implementation.

This is tested by a new test that repeatedly splits epochs.