### PR TITLE
chore: add nbstripout pre-commit hook for notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
     -   id: codespell
         args: [--ignore-words-list=nd]
         exclude: '\.ipynb$'
+
+-   repo: https://github.com/kynan/nbstripout
+    rev: 0.9.1
+    hooks:
+    -   id: nbstripout

--- a/examples/play_with_analyzer.ipynb
+++ b/examples/play_with_analyzer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1c1072b8",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Photon Mosaic: synthetic data walkthrough\n",
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "814ac864",
+   "id": "2",
    "metadata": {},
    "source": [
     "## Generate synthetic imaging data"
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,48 +89,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f39206b",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Create the ROI analyzer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "analyzer = pm.create_roi_analyzer(rois, imaging)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5474172b",
-   "metadata": {},
-   "source": [
-    "## Extract fluorescence"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fluorescence_ext = analyzer.compute(\"fluorescence\", n_jobs=4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fluorescence = fluorescence_ext.get_data(outputs=\"recording\")"
    ]
   },
   {
@@ -140,12 +102,50 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "analyzer = pm.create_roi_analyzer(rois, imaging)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "## Extract fluorescence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluorescence_ext = analyzer.compute(\"fluorescence\", n_jobs=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluorescence = fluorescence_ext.get_data(outputs=\"recording\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sw.plot_traces(fluorescence, backend=\"ipywidgets\", time_range=[0, 30])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d2d1ba3f",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Compute dF/F"
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f6749d8",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Deconvolution"
@@ -220,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d66b6b6",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1f415a0",
+   "id": "21",
    "metadata": {},
    "source": [
     "**Note:** the cell below checks which of the plotted ROIs share pixels with other ROIs.\n",
@@ -251,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f2bbc60",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25dae0db",
+   "id": "23",
    "metadata": {},
    "source": [
     "**Note:** inferred dF/F is systematically smaller than ground truth in the plot below. The\n",
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd397e18",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45cd3903",
+   "id": "25",
    "metadata": {},
    "source": [
     "**Note:** the plot below repeats the comparison above, but with each ROI's inferred trace\n",
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d7b66ba",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/play_with_analyzer.ipynb
+++ b/examples/play_with_analyzer.ipynb
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efc8acb5-b820-4c1d-9ffd-c5cbae05b1e7",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12b96492-7db4-4a68-bb0a-4b01aa9234c3",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f38b2735-bfa9-4523-89a8-b766837a1740",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a57d7305-d0c5-4918-b6d6-2c7de9353a57",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3aad05c-7ab2-47cb-8b1e-723246499971",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f004d8b-5ebf-4b5c-b136-a7a9e7a2957a",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1fc56940-220a-4001-b23c-bc1df65e5802",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8fc1051a-02b2-4308-ae8f-d8cd8cd788a8",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c90f2edd-adf3-437e-a739-2ebdbe8a92d3",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "512f9575-53b6-4923-8c11-31ddc6cfe1dc",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "541c8906",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12a3f8aa",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acd0e21c",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44f14a6a",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/segmentation.ipynb
+++ b/examples/segmentation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "intro-md",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Suite2p segmentation\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "imports",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "flow1-md",
+   "id": "2",
    "metadata": {},
    "source": [
     "## 1. Detect ROIs on a registered imaging object\n",
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "make-imaging",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "settings",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "detect-all-epochs",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "imaging-already-registered",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "per-epoch-md",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Per-epoch detection\n",
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "per-epoch",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "advanced-md",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Restricting epochs, pixel range, and bad frames\n",
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advanced",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "flow2-md",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 2. Reload a pre-computed suite2p folder\n",
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reload-folder",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reload-properties",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "imaging-elsewhere-md",
+   "id": "14",
    "metadata": {},
    "source": [
     "If your registered movie lives somewhere other than the suite2p folder (a Zarr store, a NWB file, a `BinaryFolderImaging`, ...), just register that imaging instead of `Suite2pImaging`:"
@@ -208,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "imaging-elsewhere",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "downstream-md",
+   "id": "16",
    "metadata": {},
    "source": [
     "## 3. Downstream: plotting\n",
@@ -229,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "downstream-plot",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "from-stat-md",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Appendix: `Suite2pRois.from_stat` for in-memory `stat`\n",
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "from-stat",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/simple_suite2p.ipynb
+++ b/examples/simple_suite2p.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a9b31127",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Simple `suite2p` example\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c705a40",
+   "id": "1",
    "metadata": {},
    "source": [
     "We start by importing the function that provides the sample data as a list of `Imaging` objects. We then load the data, print some information about it, and plot it."
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fb0b279",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d75ff732",
+   "id": "3",
    "metadata": {},
    "source": [
     "Next, we compute the motion correction and apply it. Again, we print information and plot the registered data alongside the raw."
@@ -45,7 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62df2df5",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "380528be",
+   "id": "5",
    "metadata": {},
    "source": [
     "Next, we use `suite2p` with its default settings to detect regions of interest (ROIs) in the registered image."
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab321517",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6c5915b",
+   "id": "7",
    "metadata": {},
    "source": [
     "TODO: Finally, we extract signals from the detected ROIs."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
   "mypy",
   "pre-commit",
   "ruff",
+  "nbstripout",
   "setuptools-scm",
   "suite2p==1.0.0.1",
   "oasis-deconv>=0.3.2",


### PR DESCRIPTION
## Summary
Adds `nbstripout` as a pre-commit hook so notebook outputs, execution counts,
and leftover metadata (`metadata.widgets`, `cell.metadata.execution`) are
stripped automatically before commit, instead of relying on manual cleanup.

Prompted by [photon-mosaic#101 (comment)](https://github.com/photon-mosaic/photon-mosaic/pull/101#issuecomment-5542867236),
where `play_with_analyzer.ipynb` was committed at 1.4MB despite cleared cell
outputs — the bloat was `metadata.widgets`, a leftover ipywidgets state blob
that `jupyter nbconvert --clear-output` doesn't touch.

## Changes
- `.pre-commit-config.yaml`: add `kynan/nbstripout` hook
- Ran the hook once against existing notebooks (no outputs/widgets to strip
  in any of them, but nbstripout also normalizes each cell's `id` field to a
  sequential integer — a cosmetic side effect, not referenced anywhere else
  in the repo)

CI already runs `pre-commit run --all-files`, so this is enforced on PRs
even for contributors who haven't run `pre-commit install` locally.
