### PR TITLE
Extending BaseImaging to track dtype to match SpikeInterface (#132)

### DIFF
--- a/src/photon_mosaic/core/baseimaging.py
+++ b/src/photon_mosaic/core/baseimaging.py
@@ -19,7 +19,7 @@ class BaseImaging(BaseExtractor, TimeSeries):
     The `_main_ids` attribute is used here for multi-plane imaging objects.
     """
 
-    def __init__(self, sampling_frequency: float, shape: tuple | list | ArrayLike):
+    def __init__(self, sampling_frequency: float, shape: tuple | list | ArrayLike, dtype: DTypeLike | None = None):
         # Should we allow users to provide 2D shape (H, W) for single plane imaging?
         if len(shape) == 2:
             shape = (shape[0], shape[1], 1)
@@ -29,6 +29,7 @@ class BaseImaging(BaseExtractor, TimeSeries):
         self._sampling_frequency = float(sampling_frequency)
         self._shape = tuple(shape)  # Image is intended as a volume (H, W, planes)
         self._average_image = None
+        self._dtype = np.dtype(dtype) if dtype is not None else None
 
     def _repr_header(self, display_name=True):
         """Generate text representation of the BaseImaging object."""
@@ -281,8 +282,10 @@ class BaseImaging(BaseExtractor, TimeSeries):
         Returns
         -------
         dtype: dtype
-            Data type of the video.
+            Dtype passed to the constructor, or inferred from the data if none was given.
         """
+        if self._dtype is not None:
+            return self._dtype
         return self.get_series(start_frame=0, end_frame=2, epoch_index=0).dtype
 
     def get_num_pixels(self) -> int:

--- a/src/photon_mosaic/preprocessing/basepreprocessor.py
+++ b/src/photon_mosaic/preprocessing/basepreprocessor.py
@@ -34,7 +34,7 @@ class BasePreprocessor(BaseImaging):
         if dtype is None:
             dtype = imaging.get_dtype()
 
-        BaseImaging.__init__(self, sampling_frequency=sampling_frequency, shape=imaging.shape)
+        BaseImaging.__init__(self, sampling_frequency=sampling_frequency, shape=imaging.shape, dtype=dtype)
         imaging.copy_metadata(self, only_main=False)
         self._parent = imaging
 

--- a/src/photon_mosaic/preprocessing/tests/test_basepreprocessor.py
+++ b/src/photon_mosaic/preprocessing/tests/test_basepreprocessor.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from photon_mosaic.core import generate_random_imaging
+from photon_mosaic.core.baseimaging import BaseImaging
 from photon_mosaic.preprocessing.basepreprocessor import (
     BasePreprocessor,
     BasePreprocessorEpoch,
@@ -36,6 +37,24 @@ class TestBasePreprocessor:
     def test_init_custom_dtype(self, imaging):
         # Verify construction succeeds with an explicit dtype
         BasePreprocessor(imaging, dtype=np.float32)
+
+    def test_get_dtype_returns_custom_dtype(self, imaging):
+        # Verify that the custom dtype is correctly returned by get_dtype()
+        reg = BasePreprocessor(imaging, dtype=np.float32)
+        assert reg.get_dtype() == np.dtype(np.float32)
+
+    def test_get_dtype_defaults_to_parent_dtype(self, imaging):
+        # Verify that the default dtype is inherited from the parent imaging object
+        reg = BasePreprocessor(imaging)
+        assert reg.get_dtype() == imaging.get_dtype()
+
+    def test_get_dtype_with_explicit_dtype_does_not_sample_parent_data(self):
+        # An imaging object with no epochs has no data to sample. If get_dtype()
+        # tried to infer the dtype from data, this would raise; an explicit
+        # dtype should be answerable from the stored value alone.
+        empty_imaging = BaseImaging(sampling_frequency=30.0, shape=(8, 9))
+        reg = BasePreprocessor(empty_imaging, dtype=np.float32)
+        assert reg.get_dtype() == np.dtype(np.float32)
 
     def test_init_rejects_non_imaging(self):
         with pytest.raises(AssertionError, match="must be a BaseImaging"):


### PR DESCRIPTION
BaseImaging extended to store dtype instead of inferring from samples so now BaseProcessor uses the dtype in constructor. 