### PR TITLE
Make ImagingSeriesWidget playback thread-safe

### DIFF
--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -376,17 +376,34 @@ class ImagingSeriesWidget(BaseWidget):
         self.play_button.button_style = "success"
 
     def _playback_loop(self):
-        """Main playback loop running in separate thread."""
+        """Main playback loop running in separate thread.
+
+        Paced by elapsed wall-clock time rather than a fixed per-iteration increment: each
+        redraw involves a full figure re-render plus a Jupyter comm/websocket round trip, which
+        can take longer than ``1 / playback_fps``. A naive ``current_frame += 1`` on a fixed
+        timer would race ahead of what's actually reached the browser -- since ipywidgets only
+        syncs the latest value, whichever intermediate frames never got flushed are silently
+        dropped, with no control over which ones. Instead, each iteration computes how many
+        frames *should* have elapsed since the last actual advance and jumps straight there --
+        deliberately skipping frames (evenly, by real elapsed time) so playback speed stays
+        correct under load, rather than an uncontrolled, backpressure-dependent frame drop. The
+        reference timestamp only moves forward on an actual advance (not every poll), so this
+        also stays correct if ``playback_fps`` changes mid-playback via the FPS slider.
+        """
         import time
 
         dp = to_attr(self.data_plot)
 
+        last_time = time.monotonic()
         while self.is_playing and self.current_frame < dp.num_frames - 1:
-            time.sleep(1.0 / self.playback_fps)
-            if self.is_playing:  # Check again in case it was stopped
-                self.current_frame += 1
+            now = time.monotonic()
+            frames_elapsed = int((now - last_time) * self.playback_fps)
+            if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
+                self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
+                last_time = now
                 # Update slider and display
                 self.frame_slider.value = self.current_frame
+            time.sleep(1.0 / (4 * self.playback_fps))
         # Stop when reaching the end
         if self.current_frame >= dp.num_frames - 1:
             self._stop_playback()

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -102,6 +102,8 @@ class ImagingSeriesWidget(BaseWidget):
 
     def plot_ipywidgets(self, data_plot, **backend_kwargs):
         """Interactive ipywidgets plot with video controls."""
+        import threading
+
         import matplotlib.pyplot as plt
         from IPython.display import display
         from spikeinterface.widgets.utils_ipywidgets import check_ipywidget_backend
@@ -117,6 +119,7 @@ class ImagingSeriesWidget(BaseWidget):
         self.play_thread = None
         self.playback_fps = min(10.0, dp.frame_rate)  # Default playback speed
         self._playback_last_time: float | None = None  # set by _start_playback/_on_fps_changed
+        self._playback_timing_lock = threading.Lock()
 
         # Sample up to 100 frames to compute a global vmin/vmax for the colormap.
         num_samples = min(100, dp.num_frames)
@@ -365,7 +368,8 @@ class ImagingSeriesWidget(BaseWidget):
         self.is_playing = True
         self.play_button.description = "⏸ Pause"
         self.play_button.button_style = "warning"
-        self._playback_last_time = time.monotonic()
+        with self._playback_timing_lock:
+            self._playback_last_time = time.monotonic()
 
         # Start playback thread
         self.play_thread = threading.Thread(target=self._playback_loop)
@@ -403,13 +407,21 @@ class ImagingSeriesWidget(BaseWidget):
 
         while self.is_playing and self.current_frame < dp.num_frames - 1:
             now = time.monotonic()
-            frames_elapsed = int((now - self._playback_last_time) * self.playback_fps)
+            reached_last_frame = False
+            with self._playback_timing_lock:
+                playback_fps = self.playback_fps
+                frames_elapsed = int((now - self._playback_last_time) * playback_fps)
+                if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
+                    self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
+                    self._playback_last_time += frames_elapsed / playback_fps
+                    reached_last_frame = self.current_frame >= dp.num_frames - 1
+                sleep_duration = 1.0 / (4 * playback_fps)
             if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
-                self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
-                self._playback_last_time += frames_elapsed / self.playback_fps
                 # Update slider and display
                 self.frame_slider.value = self.current_frame
-            time.sleep(1.0 / (4 * self.playback_fps))
+            if reached_last_frame:
+                break
+            time.sleep(sleep_duration)
         # Stop when reaching the end
         if self.current_frame >= dp.num_frames - 1:
             self._stop_playback()
@@ -423,11 +435,12 @@ class ImagingSeriesWidget(BaseWidget):
         """Handle FPS slider change."""
         import time
 
-        self.playback_fps = change["new"]
-        # Reset the pacing reference so the new rate only applies to time elapsed from here on --
-        # otherwise _playback_loop would apply it to time that already elapsed under the old rate,
-        # producing an incorrect frame jump right at the moment of the change.
-        self._playback_last_time = time.monotonic()
+        with self._playback_timing_lock:
+            self.playback_fps = change["new"]
+            # Reset the pacing reference so the new rate only applies to time elapsed from here on --
+            # otherwise _playback_loop would apply it to time that already elapsed under the old rate,
+            # producing an incorrect frame jump right at the moment of the change.
+            self._playback_last_time = time.monotonic()
 
     def _on_display_changed(self, change):
         """Handle display parameter changes (colormap, contrast)."""

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -406,11 +406,12 @@ class ImagingSeriesWidget(BaseWidget):
         dp = to_attr(self.data_plot)
 
         while self.is_playing and self.current_frame < dp.num_frames - 1:
-            now = time.monotonic()
             reached_last_frame = False
             with self._playback_timing_lock:
+                now = time.monotonic()
                 playback_fps = self.playback_fps
-                frames_elapsed = int((now - self._playback_last_time) * playback_fps)
+                elapsed_seconds = max(0.0, now - self._playback_last_time)
+                frames_elapsed = int(elapsed_seconds * playback_fps)
                 if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
                     self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
                     self._playback_last_time += frames_elapsed / playback_fps

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -414,6 +414,8 @@ class ImagingSeriesWidget(BaseWidget):
                 if not self.is_playing or self.current_frame >= dp.num_frames - 1:
                     reached_last_frame = self.current_frame >= dp.num_frames - 1
                     break
+                if self._playback_last_time is None:
+                    self._playback_last_time = time.monotonic()
                 now = time.monotonic()
                 playback_fps = self.playback_fps
                 elapsed_seconds = max(0.0, now - self._playback_last_time)

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -416,12 +416,13 @@ class ImagingSeriesWidget(BaseWidget):
                     self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
                     self._playback_last_time += frames_elapsed / playback_fps
                     reached_last_frame = self.current_frame >= dp.num_frames - 1
-                sleep_duration = 1.0 / (4 * playback_fps)
             if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
                 # Update slider and display
                 self.frame_slider.value = self.current_frame
             if reached_last_frame:
                 break
+            with self._playback_timing_lock:
+                sleep_duration = 1.0 / (4 * self.playback_fps)
             time.sleep(sleep_duration)
         # Stop when reaching the end
         if self.current_frame >= dp.num_frames - 1:

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -365,11 +365,11 @@ class ImagingSeriesWidget(BaseWidget):
         import threading
         import time
 
-        self.is_playing = True
+        with self._playback_timing_lock:
+            self.is_playing = True
+            self._playback_last_time = time.monotonic()
         self.play_button.description = "⏸ Pause"
         self.play_button.button_style = "warning"
-        with self._playback_timing_lock:
-            self._playback_last_time = time.monotonic()
 
         # Start playback thread
         self.play_thread = threading.Thread(target=self._playback_loop)
@@ -378,7 +378,8 @@ class ImagingSeriesWidget(BaseWidget):
 
     def _stop_playback(self):
         """Stop video playback."""
-        self.is_playing = False
+        with self._playback_timing_lock:
+            self.is_playing = False
         self.play_button.description = "▶ Play"
         self.play_button.button_style = "success"
 
@@ -405,32 +406,40 @@ class ImagingSeriesWidget(BaseWidget):
 
         dp = to_attr(self.data_plot)
 
-        while self.is_playing and self.current_frame < dp.num_frames - 1:
-            reached_last_frame = False
+        reached_last_frame = False
+        while True:
             with self._playback_timing_lock:
+                if not self.is_playing or self.current_frame >= dp.num_frames - 1:
+                    reached_last_frame = self.current_frame >= dp.num_frames - 1
+                    break
                 now = time.monotonic()
                 playback_fps = self.playback_fps
                 elapsed_seconds = max(0.0, now - self._playback_last_time)
                 frames_elapsed = int(elapsed_seconds * playback_fps)
-                if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
+                frame_to_display = None
+                if frames_elapsed > 0:
                     self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
                     self._playback_last_time += frames_elapsed / playback_fps
                     reached_last_frame = self.current_frame >= dp.num_frames - 1
-            if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
+                    frame_to_display = self.current_frame
+                else:
+                    reached_last_frame = False
+            if frame_to_display is not None:
                 # Update slider and display
-                self.frame_slider.value = self.current_frame
+                self.frame_slider.value = frame_to_display
             if reached_last_frame:
                 break
             with self._playback_timing_lock:
                 sleep_duration = 1.0 / (4 * self.playback_fps)
             time.sleep(sleep_duration)
         # Stop when reaching the end
-        if self.current_frame >= dp.num_frames - 1:
+        if reached_last_frame:
             self._stop_playback()
 
     def _on_frame_changed(self, change):
         """Handle frame slider change."""
-        self.current_frame = change["new"]
+        with self._playback_timing_lock:
+            self.current_frame = change["new"]
         self._update_display()
 
     def _on_fps_changed(self, change):
@@ -457,7 +466,8 @@ class ImagingSeriesWidget(BaseWidget):
         """
         dp = to_attr(self.data_plot)
         if 0 <= frame_number < dp.num_frames:
-            self.current_frame = frame_number
+            with self._playback_timing_lock:
+                self.current_frame = frame_number
             if hasattr(self, "frame_slider"):
                 self.frame_slider.value = frame_number
             self._update_display()

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -116,6 +116,7 @@ class ImagingSeriesWidget(BaseWidget):
         self.is_playing = False
         self.play_thread = None
         self.playback_fps = min(10.0, dp.frame_rate)  # Default playback speed
+        self._playback_last_time: float | None = None  # set by _start_playback/_on_fps_changed
 
         # Sample up to 100 frames to compute a global vmin/vmax for the colormap.
         num_samples = min(100, dp.num_frames)
@@ -359,10 +360,12 @@ class ImagingSeriesWidget(BaseWidget):
     def _start_playback(self):
         """Start video playback in a separate thread."""
         import threading
+        import time
 
         self.is_playing = True
         self.play_button.description = "⏸ Pause"
         self.play_button.button_style = "warning"
+        self._playback_last_time = time.monotonic()
 
         # Start playback thread
         self.play_thread = threading.Thread(target=self._playback_loop)
@@ -386,21 +389,24 @@ class ImagingSeriesWidget(BaseWidget):
         dropped, with no control over which ones. Instead, each iteration computes how many
         frames *should* have elapsed since the last actual advance and jumps straight there --
         deliberately skipping frames (evenly, by real elapsed time) so playback speed stays
-        correct under load, rather than an uncontrolled, backpressure-dependent frame drop. The
-        reference timestamp only moves forward on an actual advance (not every poll), so this
-        also stays correct if ``playback_fps`` changes mid-playback via the FPS slider.
+        correct under load, rather than an uncontrolled, backpressure-dependent frame drop.
+        ``self._playback_last_time`` advances by the exact duration of the frames just
+        consumed, not to ``now`` -- carrying over any leftover fraction of a frame period
+        instead of discarding it, so playback doesn't drift behind the requested rate over a
+        long session. ``_on_fps_changed`` resets it directly, so a rate change only governs
+        time elapsed from that point on rather than retroactively reinterpreting time already
+        accrued under the old rate.
         """
         import time
 
         dp = to_attr(self.data_plot)
 
-        last_time = time.monotonic()
         while self.is_playing and self.current_frame < dp.num_frames - 1:
             now = time.monotonic()
-            frames_elapsed = int((now - last_time) * self.playback_fps)
+            frames_elapsed = int((now - self._playback_last_time) * self.playback_fps)
             if self.is_playing and frames_elapsed > 0:  # Check again in case it was stopped
                 self.current_frame = min(self.current_frame + frames_elapsed, dp.num_frames - 1)
-                last_time = now
+                self._playback_last_time += frames_elapsed / self.playback_fps
                 # Update slider and display
                 self.frame_slider.value = self.current_frame
             time.sleep(1.0 / (4 * self.playback_fps))
@@ -415,7 +421,13 @@ class ImagingSeriesWidget(BaseWidget):
 
     def _on_fps_changed(self, change):
         """Handle FPS slider change."""
+        import time
+
         self.playback_fps = change["new"]
+        # Reset the pacing reference so the new rate only applies to time elapsed from here on --
+        # otherwise _playback_loop would apply it to time that already elapsed under the old rate,
+        # producing an incorrect frame jump right at the moment of the change.
+        self._playback_last_time = time.monotonic()
 
     def _on_display_changed(self, change):
         """Handle display parameter changes (colormap, contrast)."""

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -446,8 +446,9 @@ class ImagingSeriesWidget(BaseWidget):
         """Handle FPS slider change."""
         import time
 
+        new_fps = max(0.1, float(change["new"]))
         with self._playback_timing_lock:
-            self.playback_fps = change["new"]
+            self.playback_fps = new_fps
             # Reset the pacing reference so the new rate only applies to time elapsed from here on --
             # otherwise _playback_loop would apply it to time that already elapsed under the old rate,
             # producing an incorrect frame jump right at the moment of the change.

--- a/src/photon_mosaic/widgets/series.py
+++ b/src/photon_mosaic/widgets/series.py
@@ -3,6 +3,8 @@ from spikeinterface.widgets.base import BaseWidget, to_attr
 
 from photon_mosaic.core.baseimaging import BaseImaging
 
+_PLAYBACK_FPS_MIN = 0.1
+
 
 class ImagingSeriesWidget(BaseWidget):
     """Widget for visualizing an ImagingExtractor series with interactive controls.
@@ -234,7 +236,7 @@ class ImagingSeriesWidget(BaseWidget):
         # Playback speed control
         self.fps_slider = widgets.FloatSlider(
             value=self.playback_fps,
-            min=0.1,
+            min=_PLAYBACK_FPS_MIN,
             max=min(30.0, dp.frame_rate),
             step=0.1,
             description="Speed (fps):",
@@ -446,7 +448,7 @@ class ImagingSeriesWidget(BaseWidget):
         """Handle FPS slider change."""
         import time
 
-        new_fps = max(0.1, float(change["new"]))
+        new_fps = max(_PLAYBACK_FPS_MIN, float(change["new"]))
         with self._playback_timing_lock:
             self.playback_fps = new_fps
             # Reset the pacing reference so the new rate only applies to time elapsed from here on --

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -256,6 +256,26 @@ def test_playback_loop_skips_ahead_after_slow_iteration(monkeypatch):
     assert sleep_calls[0] == pytest.approx(0.025)
 
 
+def test_playback_loop_initializes_missing_last_time(monkeypatch):
+    harness = _PlaybackHarness(num_frames=1000, playback_fps=10, last_time=None)
+
+    fake_time = [0.0]
+    sleep_calls = []
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+
+    def fake_sleep(duration):
+        sleep_calls.append(duration)
+        harness.is_playing = False
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    harness._playback_loop()
+
+    assert harness.current_frame == 0
+    assert harness._playback_last_time == pytest.approx(0.0)
+    assert sleep_calls == [pytest.approx(0.025)]
+
+
 def test_playback_loop_stops_at_last_frame(monkeypatch):
     """Reaching the final frame should stop playback (button reset to Play)."""
     harness = _PlaybackHarness(num_frames=5, playback_fps=10, current_frame=3)

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -354,6 +354,38 @@ class _BlockingLock:
         self._lock.release()
 
 
+class _TimeAdvancingLock:
+    def __init__(self, fake_time, advanced_to):
+        self._lock = threading.Lock()
+        self.fake_time = fake_time
+        self.advanced_to = advanced_to
+        self.advanced = False
+
+    def __enter__(self):
+        self._lock.acquire()
+        if not self.advanced:
+            self.fake_time[0] = self.advanced_to
+            self.advanced = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._lock.release()
+
+
+def test_playback_loop_samples_time_inside_timing_lock(monkeypatch):
+    """The elapsed-time sample should be taken after the timing lock is acquired."""
+    fake_time = [0.0]
+    harness = _PlaybackHarness(num_frames=10_000, playback_fps=10, last_time=0.0)
+    harness._playback_timing_lock = _TimeAdvancingLock(fake_time, advanced_to=0.1)
+
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+    monkeypatch.setattr("time.sleep", lambda duration: setattr(harness, "is_playing", False))
+
+    harness._playback_loop()
+
+    assert harness.current_frame == 1
+
+
 def test_fps_change_waits_for_playback_timing_lock(monkeypatch):
     """Playback updates and FPS changes should serialize through the same timing lock."""
     harness = _PlaybackHarness(num_frames=10_000, playback_fps=10, last_time=0.0)

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -335,6 +335,17 @@ def test_fps_change_does_not_retroactively_apply_to_elapsed_time(monkeypatch):
     assert harness.current_frame == 0
 
 
+def test_fps_change_clamps_non_positive_values(monkeypatch):
+    harness = _PlaybackHarness(num_frames=10_000, playback_fps=10)
+
+    monkeypatch.setattr("time.monotonic", lambda: 1.23)
+
+    harness._on_fps_changed({"new": 0})
+
+    assert harness.playback_fps == pytest.approx(0.1)
+    assert harness._playback_last_time == pytest.approx(1.23)
+
+
 class _BlockingLock:
     def __init__(self):
         self._lock = threading.Lock()

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -372,6 +372,24 @@ class _TimeAdvancingLock:
         self._lock.release()
 
 
+class _SleepFpsLock:
+    def __init__(self, harness, updated_fps):
+        self._lock = threading.Lock()
+        self.harness = harness
+        self.updated_fps = updated_fps
+        self.enter_count = 0
+
+    def __enter__(self):
+        self._lock.acquire()
+        self.enter_count += 1
+        if self.enter_count == 2:
+            self.harness.playback_fps = self.updated_fps
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._lock.release()
+
+
 def test_playback_loop_samples_time_inside_timing_lock(monkeypatch):
     """The elapsed-time sample should be taken after the timing lock is acquired."""
     fake_time = [0.0]
@@ -384,6 +402,28 @@ def test_playback_loop_samples_time_inside_timing_lock(monkeypatch):
     harness._playback_loop()
 
     assert harness.current_frame == 1
+
+
+def test_playback_loop_rechecks_fps_before_sleep(monkeypatch):
+    """A just-applied FPS change should affect the same iteration's sleep pacing."""
+    harness = _PlaybackHarness(num_frames=10_000, playback_fps=10, last_time=0.0)
+    harness._playback_timing_lock = _SleepFpsLock(harness, updated_fps=20)
+
+    fake_time = [0.1]
+    sleep_calls = []
+
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+
+    def fake_sleep(duration):
+        sleep_calls.append(duration)
+        harness.is_playing = False
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    harness._playback_loop()
+
+    assert harness.current_frame == 1
+    assert sleep_calls == [pytest.approx(0.0125)]
 
 
 def test_fps_change_waits_for_playback_timing_lock(monkeypatch):

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -188,3 +188,84 @@ class TestImagingSeriesWidgetInit:
                 ImagingSeriesWidget(tiny, immediate_plot=True)
 
         assert captured == [10], f"expected widget to clamp end_frame to num_frames=10; calls were {captured}"
+
+
+# ---------------------------------------------------------------------------
+# ImagingSeriesWidget -- playback loop pacing
+# ---------------------------------------------------------------------------
+
+
+class _FakeButton:
+    def __init__(self):
+        self.description = ""
+        self.button_style = ""
+
+
+class _FakeSlider:
+    def __init__(self, value=0):
+        self.value = value
+
+
+class _PlaybackHarness:
+    """Minimal stand-in exposing exactly what _playback_loop/_stop_playback touch, so the
+    pacing logic can be exercised without going through __init__/plot_ipywidgets at all."""
+
+    def __init__(self, num_frames, playback_fps, current_frame=0):
+        self.data_plot = {"num_frames": num_frames}
+        self.playback_fps = playback_fps
+        self.current_frame = current_frame
+        self.is_playing = True
+        self.frame_slider = _FakeSlider(current_frame)
+        self.play_button = _FakeButton()
+
+    _playback_loop = ImagingSeriesWidget._playback_loop
+    _stop_playback = ImagingSeriesWidget._stop_playback
+
+
+def test_playback_loop_skips_ahead_after_slow_iteration(monkeypatch):
+    """A slow redraw (simulated by a big wall-clock jump between poll ticks) should make the
+    loop jump straight to the frame matching elapsed time, not silently fall one frame at a
+    time -- see _playback_loop's docstring for why a naive `current_frame += 1` on a fixed
+    timer drops frames unpredictably instead."""
+    harness = _PlaybackHarness(num_frames=1000, playback_fps=10)
+
+    fake_time = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+
+    sleep_calls = []
+
+    def fake_sleep(duration):
+        sleep_calls.append(duration)
+        if len(sleep_calls) == 1:
+            fake_time[0] += 1.0  # simulate one slow redraw stalling a full second
+        else:
+            harness.is_playing = False  # stop right after observing the post-stall frame
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    harness._playback_loop()
+
+    # at playback_fps=10, a 1s stall should skip straight to frame 10, not crawl to frame 1
+    assert harness.current_frame == 10
+    assert harness.frame_slider.value == 10
+    # poll interval is 1 / (4 * playback_fps)
+    assert sleep_calls[0] == pytest.approx(0.025)
+
+
+def test_playback_loop_stops_at_last_frame(monkeypatch):
+    """Reaching the final frame should stop playback (button reset to Play)."""
+    harness = _PlaybackHarness(num_frames=5, playback_fps=10, current_frame=3)
+
+    fake_time = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+
+    def fake_sleep(duration):
+        fake_time[0] += 1.0  # always enough to reach the end in one jump
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    harness._playback_loop()
+
+    assert harness.current_frame == 4  # num_frames - 1
+    assert harness.is_playing is False
+    assert harness.play_button.description == "▶ Play"

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import patch
 
 import numpy as np
@@ -218,6 +219,7 @@ class _PlaybackHarness:
         self.frame_slider = _FakeSlider(current_frame)
         self.play_button = _FakeButton()
         self._playback_last_time = last_time  # normally set by _start_playback/_on_fps_changed
+        self._playback_timing_lock = threading.Lock()
 
     _playback_loop = ImagingSeriesWidget._playback_loop
     _stop_playback = ImagingSeriesWidget._stop_playback
@@ -260,8 +262,10 @@ def test_playback_loop_stops_at_last_frame(monkeypatch):
 
     fake_time = [0.0]
     monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+    sleep_calls = []
 
     def fake_sleep(duration):
+        sleep_calls.append(duration)
         fake_time[0] += 1.0  # always enough to reach the end in one jump
 
     monkeypatch.setattr("time.sleep", fake_sleep)
@@ -271,6 +275,7 @@ def test_playback_loop_stops_at_last_frame(monkeypatch):
     assert harness.current_frame == 4  # num_frames - 1
     assert harness.is_playing is False
     assert harness.play_button.description == "▶ Play"
+    assert len(sleep_calls) == 1
 
 
 def test_playback_loop_does_not_drift_under_irregular_polling(monkeypatch):
@@ -328,3 +333,58 @@ def test_fps_change_does_not_retroactively_apply_to_elapsed_time(monkeypatch):
 
     # without the reset, this would advance by int(0.1 * 20) = 2 frames instead of 0
     assert harness.current_frame == 0
+
+
+class _BlockingLock:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.block_first_enter = True
+
+    def __enter__(self):
+        self._lock.acquire()
+        if self.block_first_enter:
+            self.block_first_enter = False
+            self.entered.set()
+            assert self.release.wait(timeout=1), "timed out waiting to release playback timing lock"
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._lock.release()
+
+
+def test_fps_change_waits_for_playback_timing_lock(monkeypatch):
+    """Playback updates and FPS changes should serialize through the same timing lock."""
+    harness = _PlaybackHarness(num_frames=10_000, playback_fps=10, last_time=0.0)
+    harness._playback_timing_lock = _BlockingLock()
+
+    fake_time = [0.1]
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+    monkeypatch.setattr("time.sleep", lambda duration: setattr(harness, "is_playing", False))
+
+    playback_thread = threading.Thread(target=harness._playback_loop)
+    playback_thread.start()
+
+    assert harness._playback_timing_lock.entered.wait(timeout=1), "playback loop never acquired timing lock"
+
+    fps_change_finished = threading.Event()
+
+    def change_fps():
+        harness._on_fps_changed({"new": 20})
+        fps_change_finished.set()
+
+    fps_thread = threading.Thread(target=change_fps)
+    fps_thread.start()
+
+    assert not fps_change_finished.wait(timeout=0.05), "fps change should block on playback timing lock"
+
+    harness._playback_timing_lock.release.set()
+    playback_thread.join(timeout=1)
+    fps_thread.join(timeout=1)
+
+    assert not playback_thread.is_alive()
+    assert not fps_thread.is_alive()
+    assert harness.current_frame == 1
+    assert harness.playback_fps == 20
+    assert harness._playback_last_time == pytest.approx(0.1)

--- a/src/photon_mosaic/widgets/tests/test_widgets.py
+++ b/src/photon_mosaic/widgets/tests/test_widgets.py
@@ -210,16 +210,18 @@ class _PlaybackHarness:
     """Minimal stand-in exposing exactly what _playback_loop/_stop_playback touch, so the
     pacing logic can be exercised without going through __init__/plot_ipywidgets at all."""
 
-    def __init__(self, num_frames, playback_fps, current_frame=0):
+    def __init__(self, num_frames, playback_fps, current_frame=0, last_time=0.0):
         self.data_plot = {"num_frames": num_frames}
         self.playback_fps = playback_fps
         self.current_frame = current_frame
         self.is_playing = True
         self.frame_slider = _FakeSlider(current_frame)
         self.play_button = _FakeButton()
+        self._playback_last_time = last_time  # normally set by _start_playback/_on_fps_changed
 
     _playback_loop = ImagingSeriesWidget._playback_loop
     _stop_playback = ImagingSeriesWidget._stop_playback
+    _on_fps_changed = ImagingSeriesWidget._on_fps_changed
 
 
 def test_playback_loop_skips_ahead_after_slow_iteration(monkeypatch):
@@ -269,3 +271,60 @@ def test_playback_loop_stops_at_last_frame(monkeypatch):
     assert harness.current_frame == 4  # num_frames - 1
     assert harness.is_playing is False
     assert harness.play_button.description == "▶ Play"
+
+
+def test_playback_loop_does_not_drift_under_irregular_polling(monkeypatch):
+    """Advancing the pacing reference to `now` on every frame-advance (instead of by the
+    exact duration of the frames just consumed) discards whatever fraction of a frame period
+    was left over -- silently running playback slower than the requested fps, with the gap
+    growing the longer it plays. A poll interval that doesn't evenly divide the frame period
+    (mirroring irregular real-world redraw timing) exposes this: fails against the pre-fix
+    code (lands on frame 99, not 101)."""
+    fps = 10
+    poll_step = 0.017  # deliberately does not evenly divide the frame period (0.1s)
+    num_polls = 600
+    harness = _PlaybackHarness(num_frames=10_000, playback_fps=fps)
+
+    fake_time = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+
+    calls = []
+
+    def fake_sleep(duration):
+        calls.append(duration)
+        fake_time[0] += poll_step
+        if len(calls) >= num_polls:
+            harness.is_playing = False
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    harness._playback_loop()
+
+    assert harness.current_frame == 101
+
+
+def test_fps_change_does_not_retroactively_apply_to_elapsed_time(monkeypatch):
+    """_on_fps_changed must reset the pacing reference; otherwise real time that already
+    elapsed under the old fps gets reinterpreted under the new one on the next _playback_loop
+    check, producing an incorrect frame jump right at the moment of the change (e.g. 0.1s
+    accrued at 10 fps, worth 1 frame, becomes worth 2 frames if read back at 20 fps)."""
+    harness = _PlaybackHarness(num_frames=10_000, playback_fps=10)
+
+    fake_time = [0.0]
+    monkeypatch.setattr("time.monotonic", lambda: fake_time[0])
+
+    fake_time[0] = 0.1  # 0.1s accrued under the old fps=10 (exactly 1 frame's worth)
+    harness._on_fps_changed({"new": 20})
+
+    calls = []
+
+    def fake_sleep(duration):
+        calls.append(duration)
+        harness.is_playing = False  # stop right after the first check
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+
+    harness._playback_loop()
+
+    # without the reset, this would advance by int(0.1 * 20) = 2 frames instead of 0
+    assert harness.current_frame == 0


### PR DESCRIPTION
**TL;DR:** `_playback_loop` runs in a background thread sharing mutable
state with several UI callbacks (play/pause, seek, FPS) with no
synchronization. Adds one lock making every transition atomic, a wake
event so those callbacks take effect immediately instead of waiting out
a poll interval, and a generation counter so frame publishing/rendering
can't tear or go stale. ~24 distinct races/bugs fixed. Stacked on #141.

## Summary
Stacked on top of #141 (base branch: `fix-imaging-series-playback`, not
`dev` -- depends on that PR's fixes, retarget once it merges). `68d2223`
below re-fixes the same final-frame-stop-delay bug #141 fixes separately
as `e675024` -- expect a trivial same-line conflict on rebase.

`ImagingSeriesWidget` playback (`_playback_loop`, its own thread) shares
mutable state -- `current_frame`, `_playback_last_time`, `is_playing`,
`play_thread` -- with the FPS slider, frame slider, play/pause button,
and `seek_to_frame`, all of which can run concurrently with it. None of
that access was synchronized.

## Changes
Three groups of fixes, all under one new lock (`_playback_timing_lock`):

- **State transitions made atomic**: play/pause/start/stop, the
  end-of-playback decision, mid-shutdown restarts, and a
  `_playback_start_id` generation counter so a stale "reached the end"
  decision can't cancel a fresh restart.
- **A wake event replaces polling `time.sleep`**: starting, seeking,
  changing FPS, and stopping all now interrupt a sleeping worker
  immediately instead of leaving it to notice on its own next poll (up
  to 2.5s at the slowest FPS) -- plus several edge cases in exactly when
  to clear/set that event so a wake-up landing in a gap can't get
  silently dropped.
- **Frame publishing/rendering made race-safe**: a `_frame_generation`
  counter lets a publish or a seek converge on the true state instead of
  leaving the slider stale or torn; a separate `_render_lock` (guarding
  only the Matplotlib mutations, not the slow frame fetch) stops two
  concurrent renders from interleaving into a torn frame; display
  settings (vmin/vmax/colormap) are read consistently once per render
  rather than per view.

Each fix's specific race and reasoning lives in its own commit message
and in a comment at that fix's exact location in `series.py` -- this
description gives the shape of the change, not a bullet per fix.

## Tests
A regression test per fix, each confirmed to fail against the code it
fixes -- several force genuine thread interleaving (real
`threading.Thread` + blocking-lock harnesses) rather than relying on
timing. A few review rounds also caught test-quality issues in the
harnesses themselves (a non-deterministic proof rewritten to be direct,
fake locks miscalibrated after production code shifted, one stale
docstring) -- none of which had ever failed in CI. Recently consolidated
several near-duplicate tests via `pytest.mark.parametrize`, removing
~235 lines with no coverage change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
